### PR TITLE
 Bugfix/EVUIK-95

### DIFF
--- a/projects/evo-ui-kit/src/lib/styles/reset.scss
+++ b/projects/evo-ui-kit/src/lib/styles/reset.scss
@@ -151,5 +151,5 @@ label {
 }
 
 textarea, input {
-    background-color: $color-white !important;
+    background-color: $color-white;
 }


### PR DESCRIPTION
Баг со стилями инпута (бэкграунд становится черного цвета) воспроизводится на ос Ubuntu после установки темы arc-dark.
Пофиксила, прописав точный цвет фона для инпута.

Такую же проблему нашла у evo-datepicker