### PR TITLE
fix(evo-sidebar): fixed condition for distinctUntilChanged pipe

### DIFF
--- a/projects/evo-ui-kit/src/lib/components/evo-sidebar/evo-sidebar.service.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-sidebar/evo-sidebar.service.ts
@@ -54,8 +54,8 @@ export class EvoSidebarService {
                 const throttleDelay = raw || !data.isOpen ? 0 : this.THROTTLE_TIME;
                 return timer(throttleDelay);
             }),
-            distinctUntilChanged((_, next: EvoSidebarState) => {
-                return raw ? false : next.isOpen === this.registeredSidebars[next.id].isOpen;
+            distinctUntilChanged((prev: EvoSidebarState, next: EvoSidebarState) => {
+                return raw ? false : next.isOpen;
             }),
             tap((data: EvoSidebarState) => {
                 if (!raw) {


### PR DESCRIPTION
Because of wrong condition, event after closing sidebar sometimes wasn’t firing.