### PR TITLE
refactor(module) make module definition static analysis-friendly

### DIFF
--- a/projects/evo-ui-kit/src/lib/evo-ui-kit.module.ts
+++ b/projects/evo-ui-kit/src/lib/evo-ui-kit.module.ts
@@ -84,7 +84,7 @@ export { WINDOW_PROVIDERS };
 export { EvoToastService };
 export { EvoToastTypes };
 
-export const components: any = [
+const bundle = [
     EvoAlertComponent,
     EvoButtonComponent,
     EvoCheckboxComponent,
@@ -116,16 +116,9 @@ export const components: any = [
     EvoStepperItemComponent,
     EvoToastComponent,
     EvoTextareaComponent,
-];
 
-export const directives: any = [
     EvoUiClassDirective,
     EvoClickOutsideDirective,
-];
-
-const bundle: any = [
-    ...components,
-    ...directives,
 ];
 
 @NgModule({


### PR DESCRIPTION
Убрал из `const components: any`, тип `any` так как в таком случае при генерации метаданных компилятор не может проследить типы и вывести в метаданные все что необходимо.

Это не было проблемой до появления Webstorm 2019.1 в котором ребята из Jetbrains решили что они 💪и понимают в статическом анализе больше чем команда Google/Angular, вот так выглядят компоненты у меня без этого фикса: 

![image](https://user-images.githubusercontent.com/1586852/58704661-14058e00-83ad-11e9-9712-2c2667220c0c.png)

Все компоненты красные, на всё ругается их просто "не существует" для IDE. 
