### PR TITLE
WIP: Angular 8 (Минимум) совместимый evoUiClass

### DIFF
--- a/projects/evo-ui-kit/package.json
+++ b/projects/evo-ui-kit/package.json
@@ -2,8 +2,8 @@
   "name": "@evo/ui-kit",
   "version": "2.6.1",
   "peerDependencies": {
-    "@angular/common": "^7.0.3",
-    "@angular/core": "^7.0.3",
+    "@angular/common": ">=7.0.0 <9.0.0",
+    "@angular/core": ">=7.0.0 <9.0.0",
     "angular-imask": "^4.1.3",
     "ngx-page-scroll": "^5.0.0",
     "rxjs": "^6.3.3",

--- a/projects/evo-ui-kit/src/lib/directives/evo-ui-class.directive.ts
+++ b/projects/evo-ui-kit/src/lib/directives/evo-ui-class.directive.ts
@@ -1,5 +1,19 @@
-import { Directive, ElementRef, Input, IterableDiffers, KeyValueDiffers, Renderer2, OnDestroy } from '@angular/core';
-import { NgClass } from '@angular/common';
+import {
+    Directive,
+    ElementRef,
+    Input,
+    IterableDiffers,
+    KeyValueDiffers,
+    Renderer2,
+    OnDestroy,
+    DoCheck,
+    IterableChanges,
+    IterableDiffer,
+    KeyValueChanges,
+    KeyValueDiffer,
+    ɵisListLikeIterable as isListLikeIterable,
+    ɵstringify as stringify,
+} from '@angular/core';
 import { Subject } from 'rxjs';
 import { distinctUntilChanged, tap, takeUntil } from 'rxjs/operators';
 
@@ -7,6 +21,166 @@ const isObject = (item) => item != null && typeof item === 'object';
 const isString = (item) => typeof item === 'string';
 const isArray = (item) => Array.isArray(item);
 const isUndefined = (item) => typeof item === 'undefined';
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+
+/**
+ * @ngModule CommonModule
+ *
+ * @usageNotes
+ * ```
+ *     <some-element [ngClass]="'first second'">...</some-element>
+ *
+ *     <some-element [ngClass]="['first', 'second']">...</some-element>
+ *
+ *     <some-element [ngClass]="{'first': true, 'second': true, 'third': false}">...</some-element>
+ *
+ *     <some-element [ngClass]="stringExp|arrayExp|objExp">...</some-element>
+ *
+ *     <some-element [ngClass]="{'class1 class2 class3' : true}">...</some-element>
+ * ```
+ *
+ * @description
+ *
+ * Adds and removes CSS classes on an HTML element.
+ *
+ * The CSS classes are updated as follows, depending on the type of the expression evaluation:
+ * - `string` - the CSS classes listed in the string (space delimited) are added,
+ * - `Array` - the CSS classes declared as Array elements are added,
+ * - `Object` - keys are CSS classes that get added when the expression given in the value
+ *              evaluates to a truthy value, otherwise they are removed.
+ *
+ * @publicApi
+ */
+class NgClass implements DoCheck {
+    // TODO(issue/24571): remove '!'.
+    private _iterableDiffer !: IterableDiffer<string> | null;
+    // TODO(issue/24571): remove '!'.
+    private _keyValueDiffer !: KeyValueDiffer<string, any> | null;
+    private _initialClasses: string[] = [];
+    // TODO(issue/24571): remove '!'.
+    private _rawClass !: string[] | Set<string> | { [klass: string]: any };
+
+    constructor(
+        private _iterableDiffers: IterableDiffers, private _keyValueDiffers: KeyValueDiffers,
+        private _ngEl: ElementRef, private _renderer: Renderer2) {}
+
+    @Input('class')
+    set klass(value: string) {
+        this._removeClasses(this._initialClasses);
+        this._initialClasses = typeof value === 'string' ? value.split(/\s+/) : [];
+        this._applyClasses(this._initialClasses);
+        this._applyClasses(this._rawClass);
+    }
+
+    @Input()
+    set ngClass(value: string | string[] | Set<string> | { [klass: string]: any }) {
+        this._removeClasses(this._rawClass);
+        this._applyClasses(this._initialClasses);
+
+        this._iterableDiffer = null;
+        this._keyValueDiffer = null;
+
+        this._rawClass = typeof value === 'string' ? value.split(/\s+/) : value;
+
+        if (this._rawClass) {
+            if (isListLikeIterable(this._rawClass)) {
+                this._iterableDiffer = this._iterableDiffers.find(this._rawClass).create();
+            } else {
+                this._keyValueDiffer = this._keyValueDiffers.find(this._rawClass).create();
+            }
+        }
+    }
+
+    ngDoCheck(): void {
+        if (this._iterableDiffer) {
+            const iterableChanges = this._iterableDiffer.diff(this._rawClass as string[]);
+            if (iterableChanges) {
+                this._applyIterableChanges(iterableChanges);
+            }
+        } else if (this._keyValueDiffer) {
+            const keyValueChanges = this._keyValueDiffer.diff(this._rawClass as { [k: string]: any });
+            if (keyValueChanges) {
+                this._applyKeyValueChanges(keyValueChanges);
+            }
+        }
+    }
+
+    private _applyKeyValueChanges(changes: KeyValueChanges<string, any>): void {
+        changes.forEachAddedItem((record) => this._toggleClass(record.key, record.currentValue));
+        changes.forEachChangedItem((record) => this._toggleClass(record.key, record.currentValue));
+        changes.forEachRemovedItem((record) => {
+            if (record.previousValue) {
+                this._toggleClass(record.key, false);
+            }
+        });
+    }
+
+    private _applyIterableChanges(changes: IterableChanges<string>): void {
+        changes.forEachAddedItem((record) => {
+            if (typeof record.item === 'string') {
+                this._toggleClass(record.item, true);
+            } else {
+                throw new Error(
+                    `NgClass can only toggle CSS classes expressed as strings, got ${stringify(record.item)}`);
+            }
+        });
+
+        changes.forEachRemovedItem((record) => this._toggleClass(record.item, false));
+    }
+
+    /**
+     * Applies a collection of CSS classes to the DOM element.
+     *
+     * For argument of type Set and Array CSS class names contained in those collections are always
+     * added.
+     * For argument of type Map CSS class name in the map's key is toggled based on the value (added
+     * for truthy and removed for falsy).
+     */
+    private _applyClasses(rawClassVal: string[] | Set<string> | { [klass: string]: any }) {
+        if (rawClassVal) {
+            if (Array.isArray(rawClassVal) || rawClassVal instanceof Set) {
+                (<any> rawClassVal).forEach((klass: string) => this._toggleClass(klass, true));
+            } else {
+                Object.keys(rawClassVal).forEach(klass => this._toggleClass(klass, !!rawClassVal[klass]));
+            }
+        }
+    }
+
+    /**
+     * Removes a collection of CSS classes from the DOM element. This is mostly useful for cleanup
+     * purposes.
+     */
+    private _removeClasses(rawClassVal: string[] | Set<string> | { [klass: string]: any }) {
+        if (rawClassVal) {
+            if (Array.isArray(rawClassVal) || rawClassVal instanceof Set) {
+                (<any> rawClassVal).forEach((klass: string) => this._toggleClass(klass, false));
+            } else {
+                Object.keys(rawClassVal).forEach(klass => this._toggleClass(klass, false));
+            }
+        }
+    }
+
+    private _toggleClass(klass: string, enabled: boolean): void {
+        klass = klass.trim();
+        if (klass) {
+            klass.split(/\s+/g).forEach(_klass => {
+                if (enabled) {
+                    this._renderer.addClass(this._ngEl.nativeElement, _klass);
+                } else {
+                    this._renderer.removeClass(this._ngEl.nativeElement, _klass);
+                }
+            });
+        }
+    }
+}
 
 @Directive({
     selector: '[evoUiClass]',


### PR DESCRIPTION
Быстро, грязно, работает. 

Просто скопипастил исходный код ngClass из 7 версии прямо в компонент. 

Проблема в том что в новой версии используются новые флаги для того что бы выбрать какую версию использовать: Rendere2/Rendere3 (Ivy)

Переписать ваш uiClass с использованием нового кода из Angular 8 означает потерять обратную совместимость с 7 версией (я не знаю сколько у вас проектов и как быстро они обновляются) 

Поэтому это быстрый, безопасный и рабочий вариант позволяющий переехать на ng8