### PR TITLE
feat(icons): multi providers

### DIFF
--- a/projects/evo-ui-kit/src/lib/components/evo-icon/classes/evo-icons-library.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-icon/classes/evo-icons-library.ts
@@ -2,17 +2,24 @@ import { IconsCategory } from '../interfaces/icons-category';
 import { IconsSource } from '../interfaces/icons-source';
 
 export class EvoIconsLibrary {
-    categories: { name: string; iconsNames: string[]; }[];
-    shapes: IconsSource;
+    categories: { name: string; iconsNames: string[]; }[] = [];
+    shapes: IconsSource = {};
     constructor(
-        lib: IconsCategory[]
+        lib: IconsCategory[][]
     ) {
-        this.categories = lib.map(iconsCategory => {
-            return {
-                name: iconsCategory.name,
-                iconsNames: Object.keys(iconsCategory.shapes)
-            };
+        lib.forEach(categoriesArray => {
+            this.addCategories(categoriesArray);
+            this.shapes = Object.assign(this.shapes, ...categoriesArray.map(iconsCategory => iconsCategory.shapes));
         });
-        this.shapes = Object.assign({}, ...lib.map(iconsCategory => iconsCategory.shapes));
+    }
+
+    addCategories(categoriesArray: IconsCategory[]): void {
+        this.categories.push( ...categoriesArray.map(iconsCategory => {
+                return {
+                    name: iconsCategory.name,
+                    iconsNames: Object.keys(iconsCategory.shapes)
+                };
+            })
+        );
     }
 }

--- a/projects/evo-ui-kit/src/lib/components/evo-icon/evo-icon.module.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-icon/evo-icon.module.ts
@@ -5,7 +5,7 @@ import { EvoIconsLibrary } from './classes/evo-icons-library';
 import { IconsCategory } from './interfaces/icons-category';
 
 export { EvoIconsLibrary } from './classes/evo-icons-library';
-export function evoIconsLibraryGetter(iconsList: IconsCategory[]) {
+export function evoIconsLibraryGetter(iconsList: IconsCategory[][]) {
     return new EvoIconsLibrary(iconsList);
 }
 
@@ -25,11 +25,12 @@ export class EvoIconModule {
             ngModule: EvoIconModule,
             providers: [{
                 provide: ICONS_LIST_TOKEN,
-                useValue: iconsList
+                useValue: iconsList,
+                multi: true,
             }, {
                 provide: EvoIconsLibrary,
                 useFactory: evoIconsLibraryGetter,
-                deps: [ ICONS_LIST_TOKEN ]
+                deps: [ ICONS_LIST_TOKEN ],
             }]
         };
     }
@@ -38,11 +39,12 @@ export class EvoIconModule {
             ngModule: EvoIconModule,
             providers: [{
                 provide: ICONS_LIST_TOKEN,
-                useValue: iconsList
+                useValue: iconsList,
+                multi: true,
             }, {
                 provide: EvoIconsLibrary,
                 useFactory: evoIconsLibraryGetter,
-                deps: [ ICONS_LIST_TOKEN ]
+                deps: [ ICONS_LIST_TOKEN ],
             }]
         };
     }


### PR DESCRIPTION
Сейчас если к примеру в модуле сайдбара используется иконка `close` и в самом проекте используются какие либо иконки, то при добавлении EvoIconModule в проект, сервис перезаписывает объект с иконками и нужно вручную еще раз добавлять иконку `close` в модуль проекта.
Поправил это поведение, теперь в сервис попадает массив всех необходимых для модуля иконок.