### PR TITLE
Feature/evomrkt 4089

### DIFF
--- a/projects/evo-ui-kit/CHANGELOG.md
+++ b/projects/evo-ui-kit/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [5.35.0](https://github.com/evotor/Evo-UI-Kit/compare/v5.34.1...v5.35.0) (2021-03-30)
+
+
+### Bug Fixes
+
+* **evo-paginator:** first page style fix ([ca00091](https://github.com/evotor/Evo-UI-Kit/commit/ca00091ed88979c5f4dfc0c68011a29b2c47e08b))
+* **evo-paginator:** fix default visible pages ([553c690](https://github.com/evotor/Evo-UI-Kit/commit/553c690b05740c60458f2194c4147e4df2ef318c))
+
+
+### Features
+
+* **evo-paginator:** add visiblePagesLimit option ([9c53299](https://github.com/evotor/Evo-UI-Kit/commit/9c5329964dbaaf53b8e990b6d85cf9dc239f5984))
+* **evo-paginator:** add visiblePagesLimit option ([cbfcb0a](https://github.com/evotor/Evo-UI-Kit/commit/cbfcb0a2db722093446ecbda938247e279fd71f6))
+
 ## [5.34.1](https://github.com/evotor/Evo-UI-Kit/compare/v5.34.0...v5.34.1) (2021-03-29)
 
 

--- a/projects/evo-ui-kit/package.json
+++ b/projects/evo-ui-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo/ui-kit",
-  "version": "5.34.1",
+  "version": "5.35.0",
   "peerDependencies": {
     "@angular/common": ">=7.0.0 <12.0.0",
     "@angular/core": ">=7.0.0 <12.0.0",

--- a/projects/evo-ui-kit/src/lib/components/evo-checkbox/evo-checkbox.component.html
+++ b/projects/evo-ui-kit/src/lib/components/evo-checkbox/evo-checkbox.component.html
@@ -7,7 +7,8 @@
         [evoUiClass]="checkboxClass"
         [disabled]="disabled"
         [ngModel]="value"
-        (ngModelChange)="onInputChange($event)">
+        (ngModelChange)="onInputChange($event)"
+    >
     <span class="evo-checkbox__text">
         <ng-content></ng-content>
     </span>
@@ -15,4 +16,5 @@
 <evo-control-error
     *ngIf="showErrors"
     [errors]="control.errors"
-    [errorsMessages]="errorsMessages"></evo-control-error>
+    [errorsMessages]="errorsMessages"
+></evo-control-error>

--- a/projects/evo-ui-kit/src/lib/components/evo-checkbox/evo-checkbox.component.scss
+++ b/projects/evo-ui-kit/src/lib/components/evo-checkbox/evo-checkbox.component.scss
@@ -1,6 +1,12 @@
 @import '../../styles/mixins.scss';
 
+:host {
+    display: inline-block;
+}
+
 .evo-checkbox {
+    display: inline-block;
+    min-height: 24px;
     margin: 0;
 
     &__input {
@@ -10,10 +16,11 @@
     &__text {
         position: relative;
         display: inline-block;
-        padding-left: 26px;
+        padding-top: 1px;
+        padding-left: 32px;
         color: $color-text;
         font-size: 14px;
-        line-height: 20px;
+        line-height: 22px;
         cursor: pointer;
         user-select: none;
 
@@ -32,14 +39,16 @@
         &:before {
             content: '';
             position: absolute;
-            top: 2px;
+            top: 0;
             left: 0;
             box-sizing: border-box;
             width: 16px;
             height: 16px;
-            background-color: $color-white;
+            margin: 4px;
+            background: $color-white none center;
             border: 2px solid $color-disabled;
             border-radius: 2px;
+            transition: background .3s, border-color .3s;
         }
 
         input:checked + &:before {

--- a/projects/evo-ui-kit/src/lib/components/evo-control-label/evo-control-label.component.html
+++ b/projects/evo-ui-kit/src/lib/components/evo-control-label/evo-control-label.component.html
@@ -1,6 +1,11 @@
 <div class="evo-control-label">
-    <label class="evo-control-label__text">{{ label || '&nbsp;' }}</label>
+    <label class="evo-control-label__text">
+        <ng-container *ngIf="isStringLabel; else templatedLabel">{{ label || '&nbsp;' }}</ng-container>
+    </label>
     <div class="evo-control-label__content">
         <ng-content></ng-content>
     </div>
 </div>
+<ng-template #templatedLabel>
+    <ng-container [ngTemplateOutlet]="label" [ngTemplateOutletContext]="context"></ng-container>
+</ng-template>

--- a/projects/evo-ui-kit/src/lib/components/evo-control-label/evo-control-label.component.html
+++ b/projects/evo-ui-kit/src/lib/components/evo-control-label/evo-control-label.component.html
@@ -1,4 +1,6 @@
 <div class="evo-control-label">
-    <label class="evo-control-label__text">{{ label }}</label>
-    <ng-content></ng-content>
+    <label class="evo-control-label__text">{{ label || '&nbsp;' }}</label>
+    <div class="evo-control-label__content">
+        <ng-content></ng-content>
+    </div>
 </div>

--- a/projects/evo-ui-kit/src/lib/components/evo-control-label/evo-control-label.component.scss
+++ b/projects/evo-ui-kit/src/lib/components/evo-control-label/evo-control-label.component.scss
@@ -5,11 +5,19 @@
 }
 
 .evo-control-label {
+    white-space: inherit;
+
     &__text {
         display: block;
-        margin-bottom: 11px;
+        margin-right: 8px;
+        margin-bottom: 8px;
         color: $color-text-subscription;
         font-size: 14px;
-        line-height: 16px;
+        line-height: 22px;
+        white-space: inherit;
+    }
+
+    &__content {
+        white-space: normal;
     }
 }

--- a/projects/evo-ui-kit/src/lib/components/evo-control-label/evo-control-label.component.scss
+++ b/projects/evo-ui-kit/src/lib/components/evo-control-label/evo-control-label.component.scss
@@ -8,7 +8,9 @@
     white-space: inherit;
 
     &__text {
-        display: block;
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
         margin-right: 8px;
         margin-bottom: 8px;
         color: $color-text-subscription;

--- a/projects/evo-ui-kit/src/lib/components/evo-control-label/evo-control-label.component.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-control-label/evo-control-label.component.spec.ts
@@ -1,0 +1,115 @@
+import { EvoControlLabelComponent } from './evo-control-label.component';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, TemplateRef, ViewChild } from '@angular/core';
+
+const LABEL_TEXT_FROM_INPUT = 'LABEL TEXT FROM INPUT';
+const LABEL_TEXT_FROM_TEMPLATE = 'LABEL TEXT FROM TEMPLATE';
+
+@Component({
+    template: `
+        <evo-control-label [label]="labelParam" [context]="contextParam">
+            <div class="projection">inner element</div>
+        </evo-control-label>
+        <ng-template
+            #labelTemplate
+            let-contextTest="contextTest"
+        >{{ contextTest || labelTextFromTemplate }}</ng-template>
+    `,
+})
+class TestHostComponent {
+    @ViewChild('labelTemplate') templateRef: TemplateRef<any>;
+
+    labelParam: string | TemplateRef<any> = '';
+    contextParam = null;
+
+    labelTextFromTemplate = LABEL_TEXT_FROM_TEMPLATE;
+}
+
+describe('EvoControlLabelComponent', () => {
+    let component: EvoControlLabelComponent;
+    let fixture: ComponentFixture<EvoControlLabelComponent>;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [
+                EvoControlLabelComponent,
+            ],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(EvoControlLabelComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
+    it('should have empty label if [label] prop is missing', () => {
+        expect(fixture.nativeElement.querySelector('.evo-control-label__text').innerText).toBe('');
+    });
+
+    it('should have text label if [label] prop is string', () => {
+        component.label = LABEL_TEXT_FROM_INPUT;
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('.evo-control-label__text').innerText).toBe(LABEL_TEXT_FROM_INPUT);
+    });
+
+    it('should have text label if [label] prop is string and context is set', () => {
+        component.label = LABEL_TEXT_FROM_INPUT;
+        component.context = {test: 'ok'};
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('.evo-control-label__text').innerText).toBe(LABEL_TEXT_FROM_INPUT);
+    });
+});
+
+describe('EvoControlLabelComponent: with test host', () => {
+    let component: TestHostComponent;
+    let fixture: ComponentFixture<TestHostComponent>;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [
+                TestHostComponent,
+                EvoControlLabelComponent,
+            ],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestHostComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
+    it('should have empty trimmed label if [label] prop is missing', () => {
+        expect(fixture.nativeElement.querySelector('.evo-control-label__text').innerText.trim()).toBe('');
+    });
+
+    it('should have inner element projection', () => {
+        expect(fixture.nativeElement.querySelector('.projection')).toBeTruthy();
+    });
+
+    it('should have text label if [label] prop is string', () => {
+        component.labelParam = LABEL_TEXT_FROM_INPUT;
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('.evo-control-label__text').innerText).toBe(LABEL_TEXT_FROM_INPUT);
+    });
+
+    it('should support templateRef as [label] prop', () => {
+        component.labelParam = component.templateRef;
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('.evo-control-label__text').innerText).toBe(LABEL_TEXT_FROM_TEMPLATE);
+    });
+
+    it('should apply [context] to templateRef as [label] prop', () => {
+        const contextTest = 1;
+        component.labelParam = component.templateRef;
+        component.contextParam = {contextTest: contextTest};
+
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('.evo-control-label__text').innerText).toBe(`${ contextTest }`);
+    });
+});

--- a/projects/evo-ui-kit/src/lib/components/evo-control-label/evo-control-label.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-control-label/evo-control-label.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, TemplateRef } from '@angular/core';
 
 @Component({
     selector: 'evo-control-label',
@@ -6,5 +6,10 @@ import { Component, Input } from '@angular/core';
     styleUrls: ['./evo-control-label.component.scss'],
 })
 export class EvoControlLabelComponent {
-    @Input() label: string;
+    @Input() label: string | TemplateRef<any>;
+    @Input() context: Object | null;
+
+    get isStringLabel(): boolean {
+        return typeof this.label === 'string';
+    }
 }

--- a/projects/evo-ui-kit/src/lib/components/evo-control-label/evo-control-label.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-control-label/evo-control-label.component.ts
@@ -3,7 +3,7 @@ import { Component, Input } from '@angular/core';
 @Component({
     selector: 'evo-control-label',
     templateUrl: './evo-control-label.component.html',
-    styleUrls: [ './evo-control-label.component.scss' ],
+    styleUrls: ['./evo-control-label.component.scss'],
 })
 export class EvoControlLabelComponent {
     @Input() label: string;

--- a/projects/evo-ui-kit/src/lib/components/evo-radio/evo-radio.component.scss
+++ b/projects/evo-ui-kit/src/lib/components/evo-radio/evo-radio.component.scss
@@ -1,8 +1,12 @@
 @import '../../styles/mixins.scss';
 
-$evoRadio: '.evo-radio';
+:host {
+    display: inline-block;
+}
 
-#{$evoRadio} {
+.evo-radio {
+    $parent-class: &;
+
     display: flex;
     align-items: center;
     cursor: pointer;
@@ -10,19 +14,22 @@ $evoRadio: '.evo-radio';
     &__element {
         position: relative;
         display: block;
+        flex: 0 0 20px;
         width: 20px;
         height: 20px;
-        margin-right: 20px;
+        margin: 2px 8px 2px 2px;
         padding: 4px;
         background-color: $color-white;
         border: 2px solid $color-disabled;
         border-radius: 50%;
+        transition: background .3s, border-color .3s;
 
         &:before {
+            content: '';
             position: absolute;
             top: 50%;
             left: 50%;
-            display: none;
+            display: block;
             box-sizing: border-box;
             width: 10px;
             height: 10px;
@@ -30,7 +37,10 @@ $evoRadio: '.evo-radio';
             margin-left: -5px;
             background-color: $color-link;
             border-radius: 50%;
-            content: '';
+            transform: scale(0);
+            transform-origin: center;
+            opacity: 0;
+            transition: background .3s, transform .3s;
         }
     }
 
@@ -38,14 +48,14 @@ $evoRadio: '.evo-radio';
         display: none;
 
         &[disabled] {
-            & ~ #{$evoRadio}__element {
+            & ~ #{$parent-class}__element {
                 background-color: $color-background-grey;
             }
         }
 
         &:checked {
             &[disabled] {
-                & ~ #{$evoRadio}__element {
+                & ~ #{$parent-class}__element {
                     background-color: #fff;
 
                     &:before {
@@ -54,16 +64,19 @@ $evoRadio: '.evo-radio';
                 }
             }
 
-            & ~ #{$evoRadio}__element {
+            & ~ #{$parent-class}__element {
                 &:before {
-                    display: block;
+                    transform: scale(1);
+                    opacity: 1;
                 }
             }
         }
     }
 
     &__content {
-        color: $color-black;
-        font-weight: 600;
+        color: $color-text;
+        font-size: 14px;
+        line-height: 22px;
+        user-select: none;
     }
 }

--- a/projects/evo-ui-kit/src/lib/styles/components/evo-form.scss
+++ b/projects/evo-ui-kit/src/lib/styles/components/evo-form.scss
@@ -23,144 +23,6 @@ $evo-form-min-field-width: 100px;
     }
 }
 
-.evo-form {
-    display: flex;
-    flex-direction: column;
-    margin-bottom: 40px;
-
-    .evo-form-section + .evo-form-section {
-        margin-top: 64px;
-    }
-
-    &__note {
-        width: 100%;
-        margin-top: 8px;
-        color: $color-text-subscription;
-        font-style: italic;
-    }
-
-    &__error-message {
-        align-items: center;
-        color: $color-error;
-        font-style: italic;
-    }
-
-    &__button {
-        margin-top: $evo-form-gap-ver;
-        margin-right: $evo-form-gap-hor;
-
-        &_end {
-            margin-right: 0;
-            margin-left: auto;
-        }
-
-        @media (max-width: $media-mobile) {
-            margin: $evo-form-gap-ver 0 0 0;
-        }
-    }
-
-    evo-control-label {
-        evo-input,
-        evo-select,
-        evo-autocomplete {
-            width: 100%;
-        }
-    }
-}
-
-.evo-form-section {
-    display: flex;
-    flex-direction: column;
-
-    &__title {
-        display: flex;
-        align-items: center;
-        @include h2();
-        margin-bottom: 24px;
-        font-weight: 700;
-
-        .evo-form-popover {
-            flex: 0 0 24px;
-            width: 24px;
-            height: 24px;
-            margin-left: 16px;
-        }
-    }
-
-    &__subtitle {
-        @include h4();
-        margin-bottom: 16px;
-        font-weight: 700;
-    }
-
-    .evo-form-row {
-        margin: (-$evo-form-gap-ver) (-$evo-form-gap-hor) 0 0;
-
-        @media (max-width: $media-mobile) {
-            margin: (-$evo-form-gap-ver) 0 0 0;
-        }
-    }
-
-    .evo-form-row + .evo-form-row {
-        margin-top: 0;
-    }
-
-    &_actions {
-        display: block;
-        padding-top: 0;
-        padding-bottom: $evo-form-gap-ver;
-        border-top: solid 1px $color-disabled;
-
-        .evo-form-row, .evo-form-col {
-            margin: 0;
-        }
-
-        .evo-form-row + .evo-form-row {
-            margin-top: $evo-form-gap-ver;
-        }
-
-        .evo-form__note {
-            margin: 0;
-        }
-
-        .evo-form__button {
-            margin-top: $evo-form-gap-ver;
-            margin-right: $evo-form-gap-hor;
-
-            &_end {
-                margin-right: 0;
-                margin-left: auto;
-            }
-
-            @media (max-width: $media-mobile) {
-                margin: $evo-form-gap-ver 0 0 0;
-            }
-        }
-    }
-
-    .evo-form-row + &__subtitle {
-        margin-top: $evo-form-gap-ver;
-    }
-}
-
-.evo-form-row {
-    position: relative;
-    display: flex;
-    flex-flow: row wrap;
-
-    @media (max-width: $media-mobile) {
-        flex-flow: column nowrap;
-    }
-
-    .evo-form-col:not(.evo-form-col_multi) {
-        margin: ($evo-form-gap-ver) ($evo-form-gap-hor) 0 0;
-
-        @media (max-width: $media-mobile) {
-            margin: ($evo-form-gap-ver) 0 0 0;
-        }
-    }
-}
-
 .evo-form-col {
     @media (max-width: $media-mobile) {
         &:not(&_multi) {
@@ -269,5 +131,143 @@ $evo-form-min-field-width: 100px;
 
     &_size-grow {
         flex: 1 1;
+    }
+}
+
+.evo-form-row {
+    position: relative;
+    display: flex;
+    flex-flow: row wrap;
+
+    @media (max-width: $media-mobile) {
+        flex-flow: column nowrap;
+    }
+
+    .evo-form-col:not(.evo-form-col_multi) {
+        margin: ($evo-form-gap-ver) ($evo-form-gap-hor) 0 0;
+
+        @media (max-width: $media-mobile) {
+            margin: ($evo-form-gap-ver) 0 0 0;
+        }
+    }
+}
+
+.evo-form-section {
+    display: flex;
+    flex-direction: column;
+
+    &__title {
+        display: flex;
+        align-items: center;
+        @include h2();
+        margin-bottom: 24px;
+        font-weight: 700;
+
+        .evo-form-popover {
+            flex: 0 0 24px;
+            width: 24px;
+            height: 24px;
+            margin-left: 16px;
+        }
+    }
+
+    &__subtitle {
+        @include h4();
+        margin-bottom: 16px;
+        font-weight: 700;
+    }
+
+    .evo-form-row {
+        margin: (-$evo-form-gap-ver) (-$evo-form-gap-hor) 0 0;
+
+        @media (max-width: $media-mobile) {
+            margin: (-$evo-form-gap-ver) 0 0 0;
+        }
+    }
+
+    .evo-form-row + .evo-form-row {
+        margin-top: 0;
+    }
+
+    &_actions {
+        display: block;
+        padding-top: 0;
+        padding-bottom: $evo-form-gap-ver;
+        border-top: solid 1px $color-disabled;
+
+        .evo-form-row, .evo-form-col {
+            margin: 0;
+        }
+
+        .evo-form-row + .evo-form-row {
+            margin-top: $evo-form-gap-ver;
+        }
+
+        .evo-form__note {
+            margin: 0;
+        }
+
+        .evo-form__button {
+            margin-top: $evo-form-gap-ver;
+            margin-right: $evo-form-gap-hor;
+
+            &_end {
+                margin-right: 0;
+                margin-left: auto;
+            }
+
+            @media (max-width: $media-mobile) {
+                margin: $evo-form-gap-ver 0 0 0;
+            }
+        }
+    }
+
+    .evo-form-row + &__subtitle {
+        margin-top: $evo-form-gap-ver;
+    }
+}
+
+.evo-form {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 40px;
+
+    .evo-form-section + .evo-form-section {
+        margin-top: 64px;
+    }
+
+    &__note {
+        width: 100%;
+        margin-top: 8px;
+        color: $color-text-subscription;
+        font-style: italic;
+    }
+
+    &__error-message {
+        align-items: center;
+        color: $color-error;
+        font-style: italic;
+    }
+
+    &__button {
+        margin-top: $evo-form-gap-ver;
+        margin-right: $evo-form-gap-hor;
+
+        &_end {
+            margin-right: 0;
+            margin-left: auto;
+        }
+
+        @media (max-width: $media-mobile) {
+            margin: $evo-form-gap-ver 0 0 0;
+        }
+    }
+
+    evo-control-label {
+        evo-input,
+        evo-select,
+        evo-autocomplete {
+            width: 100%;
+        }
     }
 }

--- a/projects/evo-ui-kit/src/lib/styles/components/evo-form.scss
+++ b/projects/evo-ui-kit/src/lib/styles/components/evo-form.scss
@@ -4,140 +4,22 @@ $evo-form-gap-hor: 24px;
 $evo-form-gap-ver: 32px;
 $evo-form-min-field-width: 100px;
 
-.evo-form {
-    display: flex;
-    flex-direction: column;
-    margin-bottom: 40px;
+.evo-form-popover {
+    display: inline-block;
+    flex: 0 0 16px;
+    width: 16px;
+    height: 16px;
+    margin-left: 8px;
+    color: $color-text;
+    font-weight: normal;
+    font-size: 14px;
+    line-height: 22px;
 
-    .evo-form-section + .evo-form-section {
-        margin-top: 64px;
-    }
-
-    .evo-form-row {
-        margin: (-$evo-form-gap-ver) (-$evo-form-gap-hor) 0 0;
-
-        @media (max-width: $media-mobile) {
-            margin: (-$evo-form-gap-ver) 0 0 0;
-        }
-    }
-
-    .evo-form-row + .evo-form-row {
-        margin-top: 0;
-    }
-
-    .evo-form-row .evo-form-col:not(.evo-form-col_multi) {
-        margin: ($evo-form-gap-ver) ($evo-form-gap-hor) 0 0;
-
-        @media (max-width: $media-mobile) {
-            margin: ($evo-form-gap-ver) 0 0 0;
-        }
-    }
-
-    &__note {
-        width: 100%;
-        margin-top: 8px;
-        color: $color-text-subscription;
-        font-style: italic;
-    }
-
-    &__error-message {
-        align-items: center;
-        color: $color-error;
-        font-style: italic;
-    }
-
-    &__button {
-        margin-top: $evo-form-gap-ver;
-        margin-right: $evo-form-gap-hor;
-
-        &_end {
-            margin-right: 0;
-            margin-left: auto;
-        }
-
-        @media (max-width: $media-mobile) {
-            margin: $evo-form-gap-ver 0 0 0;
-        }
-    }
-
-    evo-control-label {
-        evo-input,
-        evo-select,
-        evo-autocomplete {
-            width: 100%;
-        }
-    }
-}
-
-.evo-form-section {
-    display: flex;
-    flex-direction: column;
-
-    &__title {
-        display: flex;
-        align-items: center;
-        @include h2();
-        margin-bottom: 24px;
-        font-weight: 700;
-
-        .evo-form-popover {
-            flex: 0 0 24px;
-            width: 24px;
-            height: 24px;
-        }
-    }
-
-    &__subtitle {
-        @include h4();
-        margin-bottom: 16px;
-        font-weight: 700;
-    }
-
-    &_actions {
+    evo-icon {
         display: block;
-        padding-top: 0;
-        padding-bottom: $evo-form-gap-ver;
-        border-top: solid 1px $color-disabled;
-
-        .evo-form-row, .evo-form-col {
-            margin: 0;
-        }
-
-        .evo-form-row + .evo-form-row {
-            margin-top: $evo-form-gap-ver;
-        }
-
-        .evo-form__note {
-            margin: 0;
-        }
-
-        .evo-form__button {
-            margin-top: $evo-form-gap-ver;
-            margin-right: $evo-form-gap-hor;
-
-            &_end {
-                margin-right: 0;
-                margin-left: auto;
-            }
-
-            @media (max-width: $media-mobile) {
-                margin: $evo-form-gap-ver 0 0 0;
-            }
-        }
-    }
-
-    .evo-form-row + &__subtitle {
-        margin-top: $evo-form-gap-ver;
-    }
-}
-
-.evo-form-row {
-    position: relative;
-    display: flex;
-    flex-flow: row wrap;
-
-    @media (max-width: $media-mobile) {
-        flex-flow: column nowrap;
+        width: inherit;
+        height: inherit;
+        fill: $color-icon-dark;
     }
 }
 
@@ -252,20 +134,140 @@ $evo-form-min-field-width: 100px;
     }
 }
 
-.evo-form-popover {
-    flex: 0 0 16px;
-    width: 16px;
-    height: 16px;
-    margin-left: 16px;
-    color: $color-text;
-    font-weight: normal;
-    font-size: 14px;
-    line-height: 22px;
+.evo-form-row {
+    position: relative;
+    display: flex;
+    flex-flow: row wrap;
 
-    evo-icon {
+    @media (max-width: $media-mobile) {
+        flex-flow: column nowrap;
+    }
+
+    .evo-form-col:not(.evo-form-col_multi) {
+        margin: ($evo-form-gap-ver) ($evo-form-gap-hor) 0 0;
+
+        @media (max-width: $media-mobile) {
+            margin: ($evo-form-gap-ver) 0 0 0;
+        }
+    }
+}
+
+.evo-form-section {
+    display: flex;
+    flex-direction: column;
+
+    &__title {
+        display: flex;
+        align-items: center;
+        @include h2();
+        margin-bottom: 24px;
+        font-weight: 700;
+
+        .evo-form-popover {
+            flex: 0 0 24px;
+            width: 24px;
+            height: 24px;
+            margin-left: 16px;
+        }
+    }
+
+    &__subtitle {
+        @include h4();
+        margin-bottom: 16px;
+        font-weight: 700;
+    }
+
+    .evo-form-row {
+        margin: (-$evo-form-gap-ver) (-$evo-form-gap-hor) 0 0;
+
+        @media (max-width: $media-mobile) {
+            margin: (-$evo-form-gap-ver) 0 0 0;
+        }
+    }
+
+    .evo-form-row + .evo-form-row {
+        margin-top: 0;
+    }
+
+    &_actions {
         display: block;
-        width: inherit;
-        height: inherit;
-        fill: $color-icon-dark;
+        padding-top: 0;
+        padding-bottom: $evo-form-gap-ver;
+        border-top: solid 1px $color-disabled;
+
+        .evo-form-row, .evo-form-col {
+            margin: 0;
+        }
+
+        .evo-form-row + .evo-form-row {
+            margin-top: $evo-form-gap-ver;
+        }
+
+        .evo-form__note {
+            margin: 0;
+        }
+
+        .evo-form__button {
+            margin-top: $evo-form-gap-ver;
+            margin-right: $evo-form-gap-hor;
+
+            &_end {
+                margin-right: 0;
+                margin-left: auto;
+            }
+
+            @media (max-width: $media-mobile) {
+                margin: $evo-form-gap-ver 0 0 0;
+            }
+        }
+    }
+
+    .evo-form-row + &__subtitle {
+        margin-top: $evo-form-gap-ver;
+    }
+}
+
+.evo-form {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 40px;
+
+    .evo-form-section + .evo-form-section {
+        margin-top: 64px;
+    }
+
+    &__note {
+        width: 100%;
+        margin-top: 8px;
+        color: $color-text-subscription;
+        font-style: italic;
+    }
+
+    &__error-message {
+        align-items: center;
+        color: $color-error;
+        font-style: italic;
+    }
+
+    &__button {
+        margin-top: $evo-form-gap-ver;
+        margin-right: $evo-form-gap-hor;
+
+        &_end {
+            margin-right: 0;
+            margin-left: auto;
+        }
+
+        @media (max-width: $media-mobile) {
+            margin: $evo-form-gap-ver 0 0 0;
+        }
+    }
+
+    evo-control-label {
+        evo-input,
+        evo-select,
+        evo-autocomplete {
+            width: 100%;
+        }
     }
 }

--- a/projects/evo-ui-kit/src/lib/styles/components/evo-form.scss
+++ b/projects/evo-ui-kit/src/lib/styles/components/evo-form.scss
@@ -1,0 +1,271 @@
+@import "../mixins";
+
+$evo-form-gap-hor: 24px;
+$evo-form-gap-ver: 32px;
+$evo-form-min-field-width: 100px;
+
+.evo-form {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 40px;
+
+    .evo-form-section + .evo-form-section {
+        margin-top: 64px;
+    }
+
+    .evo-form-row {
+        margin: (-$evo-form-gap-ver) (-$evo-form-gap-hor) 0 0;
+
+        @media (max-width: $media-mobile) {
+            margin: (-$evo-form-gap-ver) 0 0 0;
+        }
+    }
+
+    .evo-form-row + .evo-form-row {
+        margin-top: 0;
+    }
+
+    .evo-form-row .evo-form-col:not(.evo-form-col_multi) {
+        margin: ($evo-form-gap-ver) ($evo-form-gap-hor) 0 0;
+
+        @media (max-width: $media-mobile) {
+            margin: ($evo-form-gap-ver) 0 0 0;
+        }
+    }
+
+    &__note {
+        width: 100%;
+        margin-top: 8px;
+        color: $color-text-subscription;
+        font-style: italic;
+    }
+
+    &__error-message {
+        align-items: center;
+        color: $color-error;
+        font-style: italic;
+    }
+
+    &__button {
+        margin-top: $evo-form-gap-ver;
+        margin-right: $evo-form-gap-hor;
+
+        &_end {
+            margin-right: 0;
+            margin-left: auto;
+        }
+
+        @media (max-width: $media-mobile) {
+            margin: $evo-form-gap-ver 0 0 0;
+        }
+    }
+
+    evo-control-label {
+        evo-input,
+        evo-select,
+        evo-autocomplete {
+            width: 100%;
+        }
+    }
+}
+
+.evo-form-section {
+    display: flex;
+    flex-direction: column;
+
+    &__title {
+        display: flex;
+        align-items: center;
+        @include h2();
+        margin-bottom: 24px;
+        font-weight: 700;
+
+        .evo-form-popover {
+            flex: 0 0 24px;
+            width: 24px;
+            height: 24px;
+        }
+    }
+
+    &__subtitle {
+        @include h4();
+        margin-bottom: 16px;
+        font-weight: 700;
+    }
+
+    &_actions {
+        display: block;
+        padding-top: 0;
+        padding-bottom: $evo-form-gap-ver;
+        border-top: solid 1px $color-disabled;
+
+        .evo-form-row, .evo-form-col {
+            margin: 0;
+        }
+
+        .evo-form-row + .evo-form-row {
+            margin-top: $evo-form-gap-ver;
+        }
+
+        .evo-form__note {
+            margin: 0;
+        }
+
+        .evo-form__button {
+            margin-top: $evo-form-gap-ver;
+            margin-right: $evo-form-gap-hor;
+
+            &_end {
+                margin-right: 0;
+                margin-left: auto;
+            }
+
+            @media (max-width: $media-mobile) {
+                margin: $evo-form-gap-ver 0 0 0;
+            }
+        }
+    }
+
+    .evo-form-row + &__subtitle {
+        margin-top: $evo-form-gap-ver;
+    }
+}
+
+.evo-form-row {
+    position: relative;
+    display: flex;
+    flex-flow: row wrap;
+
+    @media (max-width: $media-mobile) {
+        flex-flow: column nowrap;
+    }
+}
+
+.evo-form-col {
+    @media (max-width: $media-mobile) {
+        &:not(&_multi) {
+            flex: 0 1 auto;
+        }
+
+        &:not(&_size-1):not(&_size-2) {
+            width: 100%;
+            max-width: 100%;
+        }
+    }
+
+    &__static-value {
+        display: block;
+        font-size: 16px;
+        line-height: 24px;
+    }
+
+    /**
+     Use it in case if you need to wrap several controls into single column.
+
+     You can use single .evo-form__note for these wrapped controls.
+
+     Example:
+
+     <div class="evo-form-col evo-form-col_size-6">
+        <div class="evo-form-col evo-form-col_multi">
+            <evo-control-label class="evo-form-col evo-form-col_size-3" label="Электронная почта">
+                <evo-input></evo-input>
+            </evo-control-label>
+            <evo-control-label class="evo-form-col evo-form-col_size-3" label="Повторите электронную почту">
+                <evo-input></evo-input>
+            </evo-control-label>
+        </div>
+        <div class="evo-form__note">На указанную почту будут отправлены данные для работы c системой Goods</div>
+    </div>
+
+     */
+    &_multi {
+        display: flex;
+        flex: 1 1;
+        flex-flow: row wrap;
+        margin: (-$evo-form-gap-ver) (-$evo-form-gap-hor) 0 0;
+
+        .evo-form-col {
+            margin: ($evo-form-gap-ver) ($evo-form-gap-hor) 0 0;
+        }
+
+        @media (max-width: $media-mobile) {
+            flex-flow: column nowrap;
+        }
+    }
+
+    // minimal control size
+    &_size-1 {
+        flex: 0 0 $evo-form-min-field-width;
+        min-width: $evo-form-min-field-width;
+        max-width: $evo-form-min-field-width;
+    }
+
+    // 2-col field
+    &_size-2 {
+        flex: 0 0 196px;
+        width: 196px;
+    }
+
+    // 3-col field
+    &_size-3 {
+        flex: 0 1 306px;
+        max-width: 308px;
+    }
+
+    // 4-col field
+    &_size-4 {
+        flex: 0 1 416px;
+        max-width: 418px;
+    }
+
+    // 5-col field
+    &_size-5 {
+        flex: 0 1 526px;
+        max-width: 526px;
+    }
+
+    // 6-col field
+    &_size-6 {
+        flex: 0 1 636px;
+        max-width: 636px;
+    }
+
+    // 7-col field
+    &_size-7 {
+        flex: 0 1 746px;
+        max-width: 746px;
+    }
+
+    // 8-col field, maximal
+    &_size-8 {
+        flex: 0 1 856px;
+        max-width: 856px;
+    }
+
+    &_size-shrink {
+        flex: 0 1;
+    }
+
+    &_size-grow {
+        flex: 1 1;
+    }
+}
+
+.evo-form-popover {
+    flex: 0 0 16px;
+    width: 16px;
+    height: 16px;
+    margin-left: 16px;
+    color: $color-text;
+    font-weight: normal;
+    font-size: 14px;
+    line-height: 22px;
+
+    evo-icon {
+        display: block;
+        width: inherit;
+        height: inherit;
+        fill: $color-icon-dark;
+    }
+}

--- a/projects/evo-ui-kit/src/lib/styles/components/evo-form.scss
+++ b/projects/evo-ui-kit/src/lib/styles/components/evo-form.scss
@@ -23,6 +23,144 @@ $evo-form-min-field-width: 100px;
     }
 }
 
+.evo-form {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 40px;
+
+    .evo-form-section + .evo-form-section {
+        margin-top: 64px;
+    }
+
+    &__note {
+        width: 100%;
+        margin-top: 8px;
+        color: $color-text-subscription;
+        font-style: italic;
+    }
+
+    &__error-message {
+        align-items: center;
+        color: $color-error;
+        font-style: italic;
+    }
+
+    &__button {
+        margin-top: $evo-form-gap-ver;
+        margin-right: $evo-form-gap-hor;
+
+        &_end {
+            margin-right: 0;
+            margin-left: auto;
+        }
+
+        @media (max-width: $media-mobile) {
+            margin: $evo-form-gap-ver 0 0 0;
+        }
+    }
+
+    evo-control-label {
+        evo-input,
+        evo-select,
+        evo-autocomplete {
+            width: 100%;
+        }
+    }
+}
+
+.evo-form-section {
+    display: flex;
+    flex-direction: column;
+
+    &__title {
+        display: flex;
+        align-items: center;
+        @include h2();
+        margin-bottom: 24px;
+        font-weight: 700;
+
+        .evo-form-popover {
+            flex: 0 0 24px;
+            width: 24px;
+            height: 24px;
+            margin-left: 16px;
+        }
+    }
+
+    &__subtitle {
+        @include h4();
+        margin-bottom: 16px;
+        font-weight: 700;
+    }
+
+    .evo-form-row {
+        margin: (-$evo-form-gap-ver) (-$evo-form-gap-hor) 0 0;
+
+        @media (max-width: $media-mobile) {
+            margin: (-$evo-form-gap-ver) 0 0 0;
+        }
+    }
+
+    .evo-form-row + .evo-form-row {
+        margin-top: 0;
+    }
+
+    &_actions {
+        display: block;
+        padding-top: 0;
+        padding-bottom: $evo-form-gap-ver;
+        border-top: solid 1px $color-disabled;
+
+        .evo-form-row, .evo-form-col {
+            margin: 0;
+        }
+
+        .evo-form-row + .evo-form-row {
+            margin-top: $evo-form-gap-ver;
+        }
+
+        .evo-form__note {
+            margin: 0;
+        }
+
+        .evo-form__button {
+            margin-top: $evo-form-gap-ver;
+            margin-right: $evo-form-gap-hor;
+
+            &_end {
+                margin-right: 0;
+                margin-left: auto;
+            }
+
+            @media (max-width: $media-mobile) {
+                margin: $evo-form-gap-ver 0 0 0;
+            }
+        }
+    }
+
+    .evo-form-row + &__subtitle {
+        margin-top: $evo-form-gap-ver;
+    }
+}
+
+.evo-form-row {
+    position: relative;
+    display: flex;
+    flex-flow: row wrap;
+
+    @media (max-width: $media-mobile) {
+        flex-flow: column nowrap;
+    }
+
+    .evo-form-col:not(.evo-form-col_multi) {
+        margin: ($evo-form-gap-ver) ($evo-form-gap-hor) 0 0;
+
+        @media (max-width: $media-mobile) {
+            margin: ($evo-form-gap-ver) 0 0 0;
+        }
+    }
+}
+
 .evo-form-col {
     @media (max-width: $media-mobile) {
         &:not(&_multi) {
@@ -131,143 +269,5 @@ $evo-form-min-field-width: 100px;
 
     &_size-grow {
         flex: 1 1;
-    }
-}
-
-.evo-form-row {
-    position: relative;
-    display: flex;
-    flex-flow: row wrap;
-
-    @media (max-width: $media-mobile) {
-        flex-flow: column nowrap;
-    }
-
-    .evo-form-col:not(.evo-form-col_multi) {
-        margin: ($evo-form-gap-ver) ($evo-form-gap-hor) 0 0;
-
-        @media (max-width: $media-mobile) {
-            margin: ($evo-form-gap-ver) 0 0 0;
-        }
-    }
-}
-
-.evo-form-section {
-    display: flex;
-    flex-direction: column;
-
-    &__title {
-        display: flex;
-        align-items: center;
-        @include h2();
-        margin-bottom: 24px;
-        font-weight: 700;
-
-        .evo-form-popover {
-            flex: 0 0 24px;
-            width: 24px;
-            height: 24px;
-            margin-left: 16px;
-        }
-    }
-
-    &__subtitle {
-        @include h4();
-        margin-bottom: 16px;
-        font-weight: 700;
-    }
-
-    .evo-form-row {
-        margin: (-$evo-form-gap-ver) (-$evo-form-gap-hor) 0 0;
-
-        @media (max-width: $media-mobile) {
-            margin: (-$evo-form-gap-ver) 0 0 0;
-        }
-    }
-
-    .evo-form-row + .evo-form-row {
-        margin-top: 0;
-    }
-
-    &_actions {
-        display: block;
-        padding-top: 0;
-        padding-bottom: $evo-form-gap-ver;
-        border-top: solid 1px $color-disabled;
-
-        .evo-form-row, .evo-form-col {
-            margin: 0;
-        }
-
-        .evo-form-row + .evo-form-row {
-            margin-top: $evo-form-gap-ver;
-        }
-
-        .evo-form__note {
-            margin: 0;
-        }
-
-        .evo-form__button {
-            margin-top: $evo-form-gap-ver;
-            margin-right: $evo-form-gap-hor;
-
-            &_end {
-                margin-right: 0;
-                margin-left: auto;
-            }
-
-            @media (max-width: $media-mobile) {
-                margin: $evo-form-gap-ver 0 0 0;
-            }
-        }
-    }
-
-    .evo-form-row + &__subtitle {
-        margin-top: $evo-form-gap-ver;
-    }
-}
-
-.evo-form {
-    display: flex;
-    flex-direction: column;
-    margin-bottom: 40px;
-
-    .evo-form-section + .evo-form-section {
-        margin-top: 64px;
-    }
-
-    &__note {
-        width: 100%;
-        margin-top: 8px;
-        color: $color-text-subscription;
-        font-style: italic;
-    }
-
-    &__error-message {
-        align-items: center;
-        color: $color-error;
-        font-style: italic;
-    }
-
-    &__button {
-        margin-top: $evo-form-gap-ver;
-        margin-right: $evo-form-gap-hor;
-
-        &_end {
-            margin-right: 0;
-            margin-left: auto;
-        }
-
-        @media (max-width: $media-mobile) {
-            margin: $evo-form-gap-ver 0 0 0;
-        }
-    }
-
-    evo-control-label {
-        evo-input,
-        evo-select,
-        evo-autocomplete {
-            width: 100%;
-        }
     }
 }

--- a/projects/evo-ui-kit/src/lib/styles/main.scss
+++ b/projects/evo-ui-kit/src/lib/styles/main.scss
@@ -14,3 +14,4 @@
 @import './components/evo-title.scss';
 @import './components/evo-icon.scss';
 @import './components/evo-table.scss';
+@import './components/evo-form.scss';


### PR DESCRIPTION
Сетка для форм плюс небольшие исправления стилей компонентов

### `evo-control-label`

* добавил поддержку пустого значения лэйбла (теперь пустой лэйбл не схлапывается)
* добавил поддержку темплейтов и контекста (теперь в `[label]` можно передать ссылку на шаблон, а в `[context]` — контекст для этого шаблона)

### `evo-checkbox`
* вписал иконку в 24 px

### `evo-radio`
* вписал иконку в 24 px

Описания форм пока здесь:
https://www.notion.so/andreydev/evo-form-1f3d4afa99dd4a87819c8fc9786dac14