### PR TITLE
Добавить поддержку чисел и OnPush стратегии в EvoSelect

### DIFF
--- a/projects/evo-ui-kit/src/lib/components/evo-select/evo-select.component.html
+++ b/projects/evo-ui-kit/src/lib/components/evo-select/evo-select.component.html
@@ -1,6 +1,6 @@
 <label class="evo-select" [evoUiClass]="getSelectClasses()">
     <div class="evo-select__field" [evoUiClass]="getSelectClasses()">{{selectedLabel}}</div>
-    <select #select class="evo-select__native" [disabled]="disabled" [(ngModel)]="selectedValue" (ngModelChange)="onChange($event)">
+    <select #select class="evo-select__native" [disabled]="disabled" [ngModel]="selectedValue" (ngModelChange)="onChange($event)">
         <ng-content></ng-content>
     </select>
     <span class="evo-select__icon-arrow">

--- a/projects/evo-ui-kit/src/lib/components/evo-select/evo-select.component.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-select/evo-select.component.spec.ts
@@ -1,8 +1,8 @@
 import { async, tick, fakeAsync } from '@angular/core/testing';
 import { EvoSelectComponent } from './evo-select.component';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { ViewChild, Component } from '@angular/core';
-import { SpectatorHost, createHostFactory } from '@ngneat/spectator';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ViewChild } from '@angular/core';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
 import { EvoUiClassDirective } from '../../directives';
 import { EvoControlErrorComponent } from '../evo-control-error';
 
@@ -15,9 +15,13 @@ const options = [
 
 const formBuilder = new FormBuilder();
 
-@Component({ selector: 'evo-host-component', template: `` })
+@Component({
+    selector: 'evo-host-component',
+    template: ``,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
 class TestHostComponent {
-    options: { label: string; value: string; }[];
+    options: { label: string; value: string | number; }[];
     @ViewChild(EvoSelectComponent, {static: true}) public selectComponent: EvoSelectComponent;
     formModel: FormGroup;
 
@@ -86,8 +90,8 @@ describe('EvoSelectComponent', () => {
     });
 
     it('should have correct label when only numbers passed', () => {
-        hostComponent.options = [1, 2, 3].map(n => ({label: n.toString(), value: n}));
-        host.detectChanges();
+        hostComponent.options = [2, 3].map(n => ({label: n.toString(), value: n}));
+        host.fixture.debugElement.injector.get(ChangeDetectorRef).detectChanges();
         hostComponent.formModel.get('qty').setValue(3);
         host.detectChanges();
         expect(selectComponent.selectedLabel).toBe('3');

--- a/projects/evo-ui-kit/src/lib/components/evo-select/evo-select.component.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-select/evo-select.component.spec.ts
@@ -84,4 +84,12 @@ describe('EvoSelectComponent', () => {
         host.detectChanges();
         expect(host.query('.evo-select__field').innerHTML === newItem.label).toBeTruthy();
     });
+
+    it('should have correct label when only numbers passed', () => {
+        hostComponent.options = [1, 2, 3].map(n => ({label: n.toString(), value: n}));
+        host.detectChanges();
+        hostComponent.formModel.get('qty').setValue(3);
+        host.detectChanges();
+        expect(selectComponent.selectedLabel).toBe('3');
+    });
 });

--- a/projects/evo-ui-kit/src/lib/components/evo-select/evo-select.component.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-select/evo-select.component.spec.ts
@@ -95,4 +95,15 @@ describe('EvoSelectComponent', () => {
         hostComponent.formModel.get('qty').setValue(3);
         expect(selectComponent.selectedLabel).toBe('3');
     });
+
+    it('should convert selected option\'s value to a number', () => {
+        hostComponent.options = [1, 2, 3].map(n => ({label: n.toString(), value: n}));
+        host.fixture.debugElement.injector.get(ChangeDetectorRef).detectChanges();
+        const optionEls = host.queryAll('option') as HTMLOptionElement[];
+        const lastOption = optionEls[optionEls.length - 1];
+        const select = host.query('select') as HTMLSelectElement;
+        lastOption.selected = true;
+        select.dispatchEvent(new Event('change'));
+        expect(hostComponent.formModel.get('qty').value).toBe(3);
+    });
 });

--- a/projects/evo-ui-kit/src/lib/components/evo-select/evo-select.component.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-select/evo-select.component.spec.ts
@@ -93,7 +93,6 @@ describe('EvoSelectComponent', () => {
         hostComponent.options = [2, 3].map(n => ({label: n.toString(), value: n}));
         host.fixture.debugElement.injector.get(ChangeDetectorRef).detectChanges();
         hostComponent.formModel.get('qty').setValue(3);
-        host.detectChanges();
         expect(selectComponent.selectedLabel).toBe('3');
     });
 });

--- a/projects/evo-ui-kit/src/lib/components/evo-select/evo-select.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-select/evo-select.component.ts
@@ -96,6 +96,7 @@ export class EvoSelectComponent extends EvoBaseControl implements ControlValueAc
     writeValue(value: any) {
         if (value !== undefined) {
             this.selectedValue = value;
+            this.cdr.markForCheck();
         }
     }
 
@@ -125,6 +126,7 @@ export class EvoSelectComponent extends EvoBaseControl implements ControlValueAc
 
     setDisabledState(isDisabled: boolean) {
         this.disabled = isDisabled;
+        this.cdr.markForCheck();
     }
 
     get currentState(): IEvoControlState {


### PR DESCRIPTION
Так как обычный option хранит value в виде строки, это становится проблемой, когда работаешь с числами. 

Например, есть юзкейс с выбором кол-ва элементов на странице, массив чисел [5, 10, 20]. Прокидываю `<option *ngFor="let n of numbers" [value]="n">{{n}}</option>` в `evo-select`. И если, например, у меня есть дефолтное значение в виде 20, то `evo-select` будет показывать `selectedLabel` в виде 5, так как, во-первых, `evo-select` по дефолту сам выставляет значение первого `option`'a, во-вторых, когда прилетает мое дефолтное значение 20, то `evo-select` пытается найти `option` с таким значением, используя `===`  и не находит ничего, так как `'20'` не равно `20`. Я предлагаю использовать старый `==`, чтобы не усложнять код. Это по идее не должно быть проблемой, по крайней мере все тесты прошли. Если есть какие-то edge-кейсы, которые надо протестировать, то отпишитесь, я добавлю доп тесты. Это был первая проблема.

Еще одна проблема заключается в том, что так как `option` хранит значение в виде строки, то когда выбираешь `option`, `select` в `ngModelChange` эмитит строковое значение числа. Если мы возьмем предыдущий же пример, то я выставляю по дефолту 20, у меня в компоненте 20 это число. Потом я вручную выбираю 10 и `select` эмитит строку `'10'` и у меня в компоненте уже не число `10`, а строка `'10'`. Это не должно так работать. Я добавил конвертацию в число, если это число. Тут есть одна проблемка в случае, если используются не числа, а числоподобные строки типа `['5', '10', '20']`. В таком случае при выборе опции, выбранное значение будет конвертировано в число. Но я, если честно, не совсем понимаю зачем использовать числа в виде строки, когда можно использовать просто числа. Если кто-то уже так делает и после выбора строкового числа работает с ним дальше как со строкой, то это будет breaking change. Можно для безопасности добавить какой-нибудь флаг, по которому можно ориентироваться, форсить ли конвертацию в число или нет.

Еще была добавлена поддержка OnPush стратегии. В нашей библиотеке для тестирования, я так полагаю, та же проблема, что и в обычных ангуляровских тестах. Вызов `.detectChanges()` не вызывает `change detection` у хост компонента, а вызывает его глобально. Но так как у хост компонента стоит OnPush стратегия и у него никаких инпутов нет, то после вызова `.detectChanges()` никакие изменения не происходят. Это решается инжектом `ChangeDetectorRef`'а у хост компонента и уже у него вызывать `.detectChanges()`. Это известная давно проблема https://github.com/angular/angular/issues/12313 , которую все еще не пофиксили.