### PR TITLE
Feature/stepper labels update

### DIFF
--- a/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper-events.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper-events.ts
@@ -11,9 +11,9 @@ export class EvoStepperEvents {
 
     private events$ = new Subject<EvoStepperEvent>();
 
-    getEvents(type: EvoStepperEvent): Observable<any> {
+    getEvents(type: EvoStepperEvent): Observable<EvoStepperEvent> {
         return this.events$.pipe(
-            filter(event => event === type)
+            filter(event => event === type),
         );
     }
 

--- a/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper-events.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper-events.ts
@@ -11,8 +11,6 @@ export class EvoStepperEvents {
 
     private events$ = new Subject<EvoStepperEvent>();
 
-    constructor() { }
-
     getEvents(type: EvoStepperEvent): Observable<any> {
         return this.events$.pipe(
             filter(event => event === type)

--- a/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper-events.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper-events.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+import { filter } from 'rxjs/operators';
+
+export enum EvoStepperEvent {
+    LABEL_CHANGED = 'LABEL_CHANGED'
+}
+
+@Injectable()
+export class EvoStepperEvents {
+
+    private events$ = new Subject<EvoStepperEvent>();
+
+    constructor() { }
+
+    getEvents(type: EvoStepperEvent): Observable<any> {
+        return this.events$.pipe(
+            filter(event => event === type)
+        );
+    }
+
+    emit(type: EvoStepperEvent) {
+        this.events$.next(type);
+    }
+
+}

--- a/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper-item/evo-stepper-item.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper-item/evo-stepper-item.component.ts
@@ -1,36 +1,30 @@
-import { Component, Input, ContentChild, TemplateRef, OnChanges, SimpleChanges, Host, OnInit } from '@angular/core';
-import { EvoStepperComponent } from '../evo-stepper.component';
+import { Component, Input, ContentChild, TemplateRef, OnChanges, SimpleChanges, Host } from '@angular/core';
+import { EvoStepperEvent, EvoStepperEvents } from '../evo-stepper-events';
 
 @Component({
-  selector: 'evo-stepper-item',
-  templateUrl: './evo-stepper-item.component.html',
-  styleUrls: [ './evo-stepper-item.component.scss' ],
+    selector: 'evo-stepper-item',
+    templateUrl: './evo-stepper-item.component.html',
+    styleUrls: ['./evo-stepper-item.component.scss'],
 })
-export class EvoStepperItemComponent implements OnInit, OnChanges {
+export class EvoStepperItemComponent implements OnChanges {
 
-  @Input() label: string;
+    @Input() label: string;
 
-  isSelected = false;
+    isSelected = false;
 
-  @ContentChild(TemplateRef) contentTemp: TemplateRef<any>;
+    @ContentChild(TemplateRef) contentTemp: TemplateRef<any>;
 
-  constructor(
-      @Host()
-      private stepper: EvoStepperComponent
-  ) {}
+    constructor(
+        @Host()
+        private stepperEvents: EvoStepperEvents
+    ) { }
 
-  ngOnInit() {
-      if (!this.stepper) {
-          throw new Error('You should use EvoStepperItem only inside EvoStepper!');
-      }
-  }
+    ngOnChanges(changes: SimpleChanges) {
+        const { firstChange } = changes.label;
 
-  ngOnChanges(changes: SimpleChanges) {
-      const { firstChange } = changes.label;
-
-      if (!firstChange) {
-          this.stepper.getStepsList();
-      }
-  }
+        if (!firstChange) {
+            this.stepperEvents.emit(EvoStepperEvent.LABEL_CHANGED);
+        }
+    }
 
 }

--- a/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper-item/evo-stepper-item.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper-item/evo-stepper-item.component.ts
@@ -1,16 +1,36 @@
-import { Component, Input, ContentChild, TemplateRef } from '@angular/core';
+import { Component, Input, ContentChild, TemplateRef, OnChanges, SimpleChanges, Host, OnInit } from '@angular/core';
+import { EvoStepperComponent } from '../evo-stepper.component';
 
 @Component({
   selector: 'evo-stepper-item',
   templateUrl: './evo-stepper-item.component.html',
   styleUrls: [ './evo-stepper-item.component.scss' ],
 })
-export class EvoStepperItemComponent {
+export class EvoStepperItemComponent implements OnInit, OnChanges {
 
   @Input() label: string;
 
   isSelected = false;
 
   @ContentChild(TemplateRef) contentTemp: TemplateRef<any>;
+
+  constructor(
+      @Host()
+      private stepper: EvoStepperComponent
+  ) {}
+
+  ngOnInit() {
+      if (!this.stepper) {
+          throw new Error('You should use EvoStepperItem only inside EvoStepper!');
+      }
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+      const { firstChange } = changes.label;
+
+      if (!firstChange) {
+          this.stepper.getStepsList();
+      }
+  }
 
 }

--- a/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper.component.html
+++ b/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper.component.html
@@ -1,9 +1,11 @@
-<div class="evo-stepper">
+<div class="evo-stepper"
+    *ngIf="stepsList$ | async as stepsList"
+>
 
-  <div class="evo-stepper__current-step-name" *ngIf="stepsList">{{stepsList[currentStepIndex].label}}</div>
+  <div class="evo-stepper__current-step-name">{{stepsList[currentStepIndex].label}}</div>
 
   <!-- List -->
-  <div class="evo-stepper__list" *ngIf="stepsList">
+  <div class="evo-stepper__list">
     <div
       class="evo-stepper__item"
       *ngFor="let step of stepsList; index as i"

--- a/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper.component.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper.component.spec.ts
@@ -6,6 +6,7 @@ import { EvoUiClassDirective } from '../../directives/';
 
 @Component({ selector: 'evo-host-component', template: `` })
 class TestHostComponent {
+    labels = ['Step-1', 'Step-2', 'Step-3'];
     currentStepIndex = 0;
     clickableItems = false;
     @ViewChild(EvoStepperComponent)
@@ -15,9 +16,10 @@ class TestHostComponent {
     }
 }
 
-describe('EvoStepperComponent', () => {
+fdescribe('EvoStepperComponent', () => {
     let host: SpectatorHost<EvoStepperComponent, TestHostComponent>;
     let hostComponent: TestHostComponent;
+    let stepperComponent: EvoStepperComponent;
 
     const createHost = createHostFactory({
         component: EvoStepperComponent,
@@ -34,30 +36,31 @@ describe('EvoStepperComponent', () => {
             [currentStepIndex]="currentStepIndex"
             [clickableItems]="clickableItems"
             (clickItem)="handleClick($event)">
-        <evo-stepper-item class="step-1" label="Step-1">
+        <evo-stepper-item class="step-1" [label]="labels[0]">
             <p class="step-content">Step content 1<p>
             <button class="btn-next" (click)="currentStepIndex = 1">Next</button>
         </evo-stepper-item>
-        <evo-stepper-item label="Step-2">
+        <evo-stepper-item [label]="labels[1]">
             <p class="step-content">Step content 2<p>
         </evo-stepper-item>
-        <evo-stepper-item label="Step-3">
+        <evo-stepper-item [label]="labels[2]">
             <p class="step-content">Step content 3<p>
         </evo-stepper-item>
         </evo-stepper>`);
         hostComponent = host.hostComponent;
+        stepperComponent = hostComponent.stepperComponent;
     }));
 
     it('should have current step with index = 0, after construction', () => {
         host.detectChanges();
-        expect(host.hostComponent.stepperComponent.currentStepIndex).toEqual(0);
+        expect(stepperComponent.currentStepIndex).toEqual(0);
         expect(host.query('.step-content').textContent).toEqual('Step content 1');
     });
 
     it('should have current step with index = 1, after click', () => {
         host.detectChanges();
         host.click('.btn-next');
-        expect(hostComponent.stepperComponent.currentStepIndex).toEqual(1);
+        expect(stepperComponent.currentStepIndex).toEqual(1);
         expect(host.query('.step-content').textContent).toEqual('Step content 2');
     });
 
@@ -74,8 +77,23 @@ describe('EvoStepperComponent', () => {
         host.detectChanges();
         host.click('.evo-stepper__item:nth-child(1) .evo-stepper__item-inner');
         host.detectChanges();
-        expect(hostComponent.stepperComponent.currentStepIndex).toEqual(0);
+        expect(stepperComponent.currentStepIndex).toEqual(0);
         expect(host.query('.step-content').textContent).toEqual('Step content 1');
+    });
+
+    it('should unsubscribe from steps changes on destroy', () => {
+        const subscriptions$ = stepperComponent['subscriptions$'];
+        stepperComponent.ngOnDestroy();
+        host.detectChanges();
+        expect(subscriptions$.observers.length).toEqual(0);
+        expect(subscriptions$.isStopped).toEqual(true);
+    });
+
+    it('should update step label if input changed', () => {
+        const newLabelValue = 'First step';
+        hostComponent.labels[0] = newLabelValue;
+        host.detectChanges();
+        expect(host.query('.evo-stepper__item-name').textContent).toEqual(newLabelValue);
     });
 
 });

--- a/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper.component.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper.component.spec.ts
@@ -16,7 +16,7 @@ class TestHostComponent {
     }
 }
 
-fdescribe('EvoStepperComponent', () => {
+describe('EvoStepperComponent', () => {
     let host: SpectatorHost<EvoStepperComponent, TestHostComponent>;
     let hostComponent: TestHostComponent;
     let stepperComponent: EvoStepperComponent;
@@ -79,14 +79,6 @@ fdescribe('EvoStepperComponent', () => {
         host.detectChanges();
         expect(stepperComponent.currentStepIndex).toEqual(0);
         expect(host.query('.step-content').textContent).toEqual('Step content 1');
-    });
-
-    it('should unsubscribe from steps changes on destroy', () => {
-        const subscriptions$ = stepperComponent['subscriptions$'];
-        stepperComponent.ngOnDestroy();
-        host.detectChanges();
-        expect(subscriptions$.observers.length).toEqual(0);
-        expect(subscriptions$.isStopped).toEqual(true);
     });
 
     it('should update step label if input changed', () => {

--- a/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper.component.ts
@@ -4,12 +4,16 @@ import {
 } from '@angular/core';
 import { EvoStepperItemComponent } from './evo-stepper-item/evo-stepper-item.component';
 import { takeUntil, tap } from 'rxjs/operators';
-import { concat, asyncScheduler, of, scheduled, Subject } from 'rxjs';
+import { concat, asyncScheduler, of, scheduled, Subject, merge } from 'rxjs';
+import { EvoStepperEvent, EvoStepperEvents } from './evo-stepper-events';
 
 @Component({
     selector: 'evo-stepper',
     templateUrl: './evo-stepper.component.html',
     styleUrls: [ './evo-stepper.component.scss' ],
+    providers: [
+        EvoStepperEvents,
+    ]
 })
 export class EvoStepperComponent implements AfterViewInit, OnChanges, OnDestroy {
 
@@ -27,10 +31,17 @@ export class EvoStepperComponent implements AfterViewInit, OnChanges, OnDestroy 
 
     private subscriptions$ = new Subject();
 
+    constructor(
+        private stepperEvents: EvoStepperEvents,
+    ) {}
+
     ngAfterViewInit() {
         concat(
             scheduled(of(null), asyncScheduler),
-            this.stepComponentsList.changes,
+            merge(
+                this.stepComponentsList.changes,
+                this.stepperEvents.getEvents(EvoStepperEvent.LABEL_CHANGED)
+            )
         ).pipe(
             tap(() => this.getStepsList()),
             takeUntil(this.subscriptions$),

--- a/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper.component.ts
@@ -1,6 +1,6 @@
 import {
     Component, Input, QueryList, ContentChildren,
-    SimpleChanges, OnChanges, Output, EventEmitter, AfterViewInit, OnDestroy,
+    SimpleChanges, OnChanges, Output, EventEmitter, AfterViewInit, OnDestroy, ChangeDetectorRef,
 } from '@angular/core';
 import { EvoStepperItemComponent } from './evo-stepper-item/evo-stepper-item.component';
 import { takeUntil, tap } from 'rxjs/operators';
@@ -32,6 +32,7 @@ export class EvoStepperComponent implements AfterViewInit, OnChanges, OnDestroy 
     private subscriptions$ = new Subject();
 
     constructor(
+        private cd: ChangeDetectorRef,
         private stepperEvents: EvoStepperEvents,
     ) {}
 
@@ -64,12 +65,14 @@ export class EvoStepperComponent implements AfterViewInit, OnChanges, OnDestroy 
         this.stepsList = this.stepComponentsList.map((step: EvoStepperItemComponent, i: number) => ({ label: step.label }));
         const currentStepComponents = this.stepComponentsList.find((stepComponent, i) => i === this.currentStepIndex);
         currentStepComponents.isSelected = true;
+        this.cd.markForCheck();
     }
 
     changeCurrentStep(index: number) {
         this.stepComponentsList.forEach((step, i) => step.isSelected = (index === i));
         this.currentStepIndex = index;
         this.onChange.emit(index);
+        this.cd.markForCheck();
     }
 
     handleItemClick(index: number) {


### PR DESCRIPTION
В новой заявке на эквайринг названия шагов в степпере меняются динамически ([макеты](https://www.figma.com/file/FeBSlfskw7GN2PkIB8REEW/%D0%9F%D0%BE%D0%B4%D0%B0%D1%87%D0%B0-%D0%B7%D0%B0%D1%8F%D0%B2%D0%BA%D0%B8-%D0%BD%D0%B0-%D1%8D%D0%BA%D0%B2%D0%B0%D0%B9%D1%80%D0%B8%D0%BD%D0%B3)). К примеру лейбл шага "Организация" при переходе на следующий шаг меняется на название выбранной организации.

Сделана обработка обновления `@Input() label` на `EvoStepperItemComponent` и вызов метода родителя для отрисовки списка шагов.