### PR TITLE
fix(autocomplete): markforcheck on touched state changed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,7 @@ indent_style = space
 indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
+quote_type = single
 
 [*.md]
 max_line_length = off

--- a/projects/evo-ui-kit/src/lib/common/evo-control-touched-state.ts
+++ b/projects/evo-ui-kit/src/lib/common/evo-control-touched-state.ts
@@ -1,0 +1,56 @@
+import { AbstractControl } from '@angular/forms';
+import { Subject } from 'rxjs';
+
+// Global registry of streams with counter of subscribers for touched state
+const touchedStreamsRegistry = new Map<AbstractControl, [Subject<void>, number]>();
+
+// Original 'markAsTouched' method from control
+let _markAsTouched: (opts?: { onlySelf?: boolean | undefined; } | undefined) => void;
+
+export class EvoControlTouchedState {
+    static getTouchedStream(
+        control: AbstractControl,
+    ): Subject<void> {
+        const record = touchedStreamsRegistry.get(control);
+
+        if (record) {
+            ++record[1];
+
+            return record[0];
+        }
+
+        const subject = new Subject<void>();
+
+        _markAsTouched = control.markAsTouched;
+
+        const markAsTouchedBinded = _markAsTouched.bind(control);
+
+        control.markAsTouched = () => {
+            markAsTouchedBinded();
+            subject.next();
+        };
+
+        touchedStreamsRegistry.set(control, [subject, 1]);
+
+        return subject;
+    }
+
+    static decrementTouchedRegistry(
+        control: AbstractControl,
+    ): void {
+        const record = touchedStreamsRegistry.get(control);
+
+        if (!record) {
+            return;
+        }
+
+        if (record[1] === 1) {
+            touchedStreamsRegistry.delete(control);
+            control.markAsTouched = _markAsTouched;
+
+            return;
+        }
+
+        --record[1];
+    }
+}

--- a/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper.component.scss
+++ b/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper.component.scss
@@ -5,6 +5,7 @@
 }
 
 $root: '.evo-stepper';
+
 #{$root} {
     &__current-step-name {
         display: none;
@@ -53,9 +54,7 @@ $root: '.evo-stepper';
             }
         }
         &_completed {
-            &:before {
-                background: $color-success;
-            }
+            &:before,
             &:after {
                 background: $color-success;
             }
@@ -102,7 +101,6 @@ $root: '.evo-stepper';
     }
     &__item-point {
         position: relative;
-        z-index: 2;
         width: 28px;
         height: 28px;
         overflow: hidden;
@@ -157,12 +155,7 @@ $root: '.evo-stepper';
             &:before,
             &:after {
                 top: 7px;
-            }
-            &:before {
                 right: calc(50% + 10px);
-            }
-            &:after {
-                left: calc(50% + 10px);
             }
             &_active {
                 #{$root}__item-point {
@@ -185,9 +178,7 @@ $root: '.evo-stepper';
             border: 2px solid $color-icon-dark;
 
         }
-        &__item-name {
-            display: none;
-        }
+        &__item-name,
         &__item-number {
             display: none;
         }


### PR DESCRIPTION
Есть кейс, после вызова `FormHelper.validateControls(this.formGroup);` все не валидные инпуты подсвечиваются красным, но не `evo-autocomplete` так как он на `OnPush`и view не проверяется.
Сделал workaround с классом который подменяет метод контрола и возвращает `Subject` по которому можно получить изменения для touched state.
Отчасти способ варварский, но работает и других вариантов в голову не пришло. Если будем переводить `evo-input` на OnPush там естественно тоже такое понадобится.
Глянул у Тинька тоже есть такие траблы - https://github.com/TinkoffCreditSystems/taiga-ui/blob/main/projects/kit/components/field-error/field-error.component.ts#L26
Но у них по всей видимости по дизайну не валидный контрол не обводится красным (только ошибка выводится) что кажется странным 🧐

<img src="https://user-images.githubusercontent.com/7387686/130598516-87353428-d435-425a-b9a6-a5c0f9593e7a.png" width="600">
