### PR TITLE
feat(evo-input): add mask validation

### DIFF
--- a/projects/evo-ui-kit/src/lib/components/evo-input/evo-input.component.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-input/evo-input.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core
 import { EvoUiClassDirective } from '../../directives';
 import { EvoControlErrorComponent } from '../evo-control-error';
 import * as IMask from 'imask';
-import { COMPOSITION_BUFFER_MODE } from '@angular/forms';
+import { COMPOSITION_BUFFER_MODE, FormControl } from '@angular/forms';
 import { Component, ViewChild } from '@angular/core';
 import { createHostFactory } from '@ngneat/spectator';
 
@@ -15,6 +15,7 @@ class EvoInputWrapperComponent {
     @ViewChild(EvoInputComponent) evoInputComponent: EvoInputComponent;
 
     templateVars: any = {};
+    control = new FormControl();
 }
 
 const createHost = createHostFactory({
@@ -533,5 +534,55 @@ describe('EvoInputComponent: under test host', () => {
 
         fixture.detectChanges();
         expect(fixture.nativeElement.querySelector('.evo-input .evo-input__prefix-icon .evo-icon')).toBeTruthy();
+    });
+
+    it('should set control as invalid if the value doesnt match the mask', () => {
+        createTestHost(`<evo-input
+            [formControl]="control"
+            [mask]="{ mask: '+{7} (000) 000-00-00' }"
+            [maskValidation]="true">
+        </evo-input>`);
+
+        wrapperComponent.control.setValue('923034');
+
+        fixture.detectChanges();
+
+        expect(wrapperComponent.control.invalid).toBeTruthy();
+    });
+
+    it('should set control as valid if the value matches the mask', () => {
+        createTestHost(`<evo-input
+            [formControl]="control"
+            [mask]="{ mask: '+{7} (000) 000-00-00' }"
+            [maskValidation]="true">
+        </evo-input>`);
+
+        wrapperComponent.control.setValue('79230343434');
+
+        fixture.detectChanges();
+
+        expect(wrapperComponent.control.valid).toBeTruthy();
+    });
+
+    it('shouldnt validate the mask', () => {
+        createTestHost(`<evo-input
+            [formControl]="control"
+            [mask]="{ mask: '+{7} (000) 000-00-00' }"
+            [maskValidation]="false">
+        </evo-input>`);
+
+        wrapperComponent.control.setValue('923034');
+
+        fixture.detectChanges();
+
+        expect(wrapperComponent.control.valid).toBeTruthy();
+    });
+
+    it('shouldnt throw an error if mask is not provided and validation is disabled', () => {
+        createTestHost(`<evo-input
+            [formControl]="control">
+        </evo-input>`);
+
+        expect(true).toBeTruthy();
     });
 });

--- a/projects/evo-ui-kit/src/lib/components/evo-input/evo-input.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-input/evo-input.component.ts
@@ -18,7 +18,7 @@ import {
     SimpleChanges,
     ViewChild,
 } from '@angular/core';
-import { COMPOSITION_BUFFER_MODE, ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { COMPOSITION_BUFFER_MODE, ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validator } from '@angular/forms';
 import { EvoControlStates } from '../../common/evo-control-state-manager/evo-control-states.enum';
 import { EvoBaseControl } from '../../common/evo-base-control';
 import { fromEvent, Subject } from 'rxjs';
@@ -46,11 +46,16 @@ export enum EvoInputTheme {
             useExisting: forwardRef(() => EvoInputComponent),
             multi: true,
         },
+        {
+            provide: NG_VALIDATORS,
+            useExisting: forwardRef(() => EvoInputComponent),
+            multi: true,
+          },
     ],
 })
 export class EvoInputComponent
     extends EvoBaseControl
-    implements ControlValueAccessor, OnInit, AfterViewInit, OnChanges, OnDestroy {
+    implements ControlValueAccessor, OnInit, AfterViewInit, OnChanges, OnDestroy, Validator {
 
     @Input() autoFocus: boolean;
     // tslint:disable-next-line
@@ -67,6 +72,7 @@ export class EvoInputComponent
     @Input() inputDebounce = 50;
     @Input() unmask: boolean | 'typed' = false;
     @Input() clearable = false;
+    @Input() maskValidation = false;
 
     @Output() blur: EventEmitter<any> = new EventEmitter<any>();
 
@@ -363,5 +369,12 @@ export class EvoInputComponent
             this.tooltipElement.nativeElement.children.length > 0;
         this.customTooltipChecked = true;
         this.changeDetector.detectChanges();
+    }
+
+    validate() {
+        if (this.maskValidation && this.mask && !this.iMask.masked.isComplete) {
+            return { mask: true };
+        }
+        return null;
     }
 }

--- a/src/stories/components/evo-input.stories.ts
+++ b/src/stories/components/evo-input.stories.ts
@@ -1,4 +1,4 @@
-import { FormBuilder, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormBuilder, FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { moduleMetadata, storiesOf } from '@storybook/angular';
 import { action } from '@storybook/addon-actions';
 import { EvoButtonModule, EvoIconModule, EvoInputModule } from '@evo/ui-kit';
@@ -70,6 +70,26 @@ storiesOf('Components/Input', module)
             mask: {
                 mask: '+{7} (000) 000-00-00',
             },
+        },
+    }))
+    .add('with mask validation', () => ({
+        styleUrls: ['../../assets/scss/story-global.scss'],
+        template: `
+            <div class="story-container">
+                <evo-input
+                    [formControl]="control"
+                    placeholder="+{7} (000) 000-00-00"
+                    [mask]="mask"
+                    [maskValidation]="true">
+                </evo-input>
+                <div>Статус: {{ control.status }}</div>
+            </div>
+        `,
+        props: {
+            mask: {
+                mask: '+{7} (000) 000-00-00',
+            },
+            control: new FormControl(''),
         },
     }))
     .add('with placeholder', () => ({


### PR DESCRIPTION
Добавил валидацию инпута по маске. Частенько бывает, что необходимо добавить маску на инпут (телефон, ИНН, номер карты), но одной маски недостаточно, не просто так ведь маску добавляют, а чтобы данные соответствовали маске.