### PR TITLE
fix(evo-autocomplete): dropdown with header and footer height calculation

### DIFF
--- a/projects/evo-ui-kit/src/lib/components/evo-autocomplete/components/evo-autocomplete/evo-autocomplete.component.scss
+++ b/projects/evo-ui-kit/src/lib/components/evo-autocomplete/components/evo-autocomplete/evo-autocomplete.component.scss
@@ -234,7 +234,6 @@ evo-autocomplete {
         .ng-dropdown-panel {
             z-index: 3001;
             display: block;
-            max-height: var(--evo-dropdown-max-height, #{$dropdown-max-height});
             margin: 4px 0;
             background-color: $color-white;
             border-radius: var(--evo-autocomplete-panel-border-radius);
@@ -246,7 +245,7 @@ evo-autocomplete {
             }
 
             .ng-dropdown-panel-items {
-                max-height: inherit;
+                max-height: var(--evo-dropdown-max-height, #{$dropdown-max-height});
 
                 .ng-option {
                     overflow: var(--evo-autocomplete-option-overflow);

--- a/src/stories/components/evo-autocomplete.stories.ts
+++ b/src/stories/components/evo-autocomplete.stories.ts
@@ -888,6 +888,9 @@ export const Templates = () => ({
                 {label: 'Костя', value: '2'},
                 {label: 'Константин ', value: '3'},
                 {label: 'Джон Константин', value: '4'},
+                {label: 'Иван Иванович', value: '5'},
+                {label: 'Иван Ваныч', value: '6'},
+                {label: 'Ван Ваныч', value: '7'},
             ]),
             headerSearchControl.valueChanges.pipe(startWith(''), distinctUntilChanged()),
         ]).pipe(


### PR DESCRIPTION
проблема: наличие свойства max-height: inherit; ломает верстку с хедером (а также с футером), отсутствие ломает верстку без них.
![image](https://github.com/user-attachments/assets/1892ca20-0b7c-414a-b23f-71f9fd5efa96)


переписал под реализацию самого ng-select:
сам контейнер по высоте не ограничивается, а ограничивается обертка элементов.

для дефолтного кейса (нет хедера и футера) - визуально ничего не изменится