### PR TITLE
Fix evo-checkbox controls not working with "emitEvent: false"

### DIFF
--- a/projects/evo-ui-kit/src/lib/components/evo-checkbox/evo-checkbox.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-checkbox/evo-checkbox.component.ts
@@ -79,7 +79,7 @@ export class EvoCheckboxComponent extends EvoBaseControl implements ControlValue
     }
 
     writeValue(value: boolean): void {
-        this.value = value;
+        this._value = value;
     }
 
     // eslint-disable-next-line


### PR DESCRIPTION
fix(evo-checkbox): stop triggering on change in write value function which allow to properly use 'emitEvent: false' in controls