### PR TITLE
EVOMRKT-7845: Компоненты: пересмотреть компонент табов (v6)

### DIFF
--- a/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/evo-navigation-tab.directive.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/evo-navigation-tab.directive.spec.ts
@@ -1,0 +1,102 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {Component, DebugElement} from '@angular/core';
+import {EvoNavigationTabDirective, EVO_TAB_ACTIVATE} from './evo-navigation-tab.directive';
+import {MutationObserverService} from '../../services/mutation-observer.service';
+import {RouterLinkActiveService} from '../../services/router-link-active.service';
+import {By} from '@angular/platform-browser';
+import {Subject} from 'rxjs';
+import {Router, Routes} from '@angular/router';
+import {RouterTestingModule} from '@angular/router/testing';
+
+enum RoutePath {
+    FIRST = 'first',
+    SECOND = 'second',
+}
+
+@Component({
+    template: `
+        <button evoNavigationTab routerLinkActive="active" [routerLink]="RoutePath.FIRST">Tab 1</button>
+        <button evoNavigationTab routerLinkActive="active" [routerLink]="RoutePath.SECOND">Tab 2</button>
+        <router-outlet></router-outlet>
+    `,
+})
+class TestHostComponent {
+    RoutePath = RoutePath;
+}
+
+const routes: Routes = [
+    {path: RoutePath.FIRST, component: TestHostComponent},
+    {path: RoutePath.SECOND, component: TestHostComponent},
+];
+
+describe('EvoNavigationTabDirective', () => {
+    let fixture: ComponentFixture<TestHostComponent>;
+    let buttonsEl: DebugElement[];
+    let router: Router;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [TestHostComponent, EvoNavigationTabDirective],
+            providers: [
+                {
+                    provide: RouterLinkActiveService,
+                    useValue: new Subject<boolean>(),
+                },
+                {
+                    provide: MutationObserverService,
+                    useValue: new Subject<void>(),
+                },
+            ],
+            imports: [RouterTestingModule.withRoutes(routes)],
+        }).compileComponents();
+
+        router = TestBed.inject(Router);
+        fixture = TestBed.createComponent(TestHostComponent);
+        fixture.detectChanges();
+
+        buttonsEl = fixture.debugElement.queryAll(By.directive(EvoNavigationTabDirective));
+    });
+
+    it('should add evo-navigation-tab class to host element', () => {
+        buttonsEl.forEach((button) => {
+            expect(button.nativeElement.classList).toContain('evo-navigation-tab');
+        });
+    });
+
+    it('should dispatch EVO_TAB_ACTIVATE custom event on click', (done) => {
+        const button = buttonsEl[0].nativeElement;
+        button.parentElement.addEventListener('click', () => {
+            setTimeout(() => {
+                const event = new CustomEvent(EVO_TAB_ACTIVATE, {
+                    bubbles: true,
+                });
+                let received = false;
+                button.addEventListener(EVO_TAB_ACTIVATE, () => {
+                    received = true;
+                });
+
+                button.dispatchEvent(event);
+                expect(received).toBeTrue();
+                done();
+            }, 0);
+        });
+        button.click();
+    });
+
+    it('should add "active" class to the correct tab when navigating', async () => {
+        await router.navigate([RoutePath.FIRST]);
+        fixture.detectChanges();
+
+        const firstTab = buttonsEl[0].nativeElement;
+        const secondTab = buttonsEl[1].nativeElement;
+
+        expect(firstTab.classList).toContain('active');
+        expect(secondTab.classList).not.toContain('active');
+
+        await router.navigate([`/${RoutePath.SECOND}`]);
+        fixture.detectChanges();
+
+        expect(firstTab.classList).not.toContain('active');
+        expect(secondTab.classList).toContain('active');
+    });
+});

--- a/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/evo-navigation-tab.directive.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/evo-navigation-tab.directive.ts
@@ -1,0 +1,53 @@
+import {Directive, ElementRef, HostBinding, OnDestroy, Optional} from '@angular/core';
+import {RouterLinkActive} from '@angular/router';
+import {EMPTY, fromEvent, merge, Subject} from 'rxjs';
+import {filter, switchMap, take, takeUntil, tap} from 'rxjs/operators';
+import {RouterLinkActiveService} from '../../services/router-link-active.service';
+import {MutationObserverService} from '../../services/mutation-observer.service';
+
+export const EVO_TAB_ACTIVATE = 'evo-tab-activate';
+
+@Directive({
+    selector: 'button[evoNavigationTab]:not([routerLink]), button[evoNavigationTab][routerLink][routerLinkActive]',
+    providers: [MutationObserverService, RouterLinkActiveService],
+})
+export class EvoNavigationTabDirective implements OnDestroy {
+    @HostBinding('class.evo-navigation-tab') tabClass = true;
+
+    private readonly destroy$ = new Subject<void>();
+
+    constructor(
+        private readonly el: ElementRef,
+        private readonly routerLinkActiveService: RouterLinkActiveService,
+        @Optional() private readonly rla: RouterLinkActive,
+        @Optional() private readonly mutation: MutationObserverService,
+    ) {
+        this.initSubscriptions();
+    }
+
+    ngOnDestroy(): void {
+        this.destroy$.next();
+        this.destroy$.complete();
+    }
+
+    private initSubscriptions(): void {
+        const mutationObserver =
+            this.rla && this.mutation ? this.mutation.pipe(filter(() => this.rla.isActive)) : EMPTY;
+
+        merge(
+            mutationObserver,
+            this.routerLinkActiveService.pipe(filter((r) => r)),
+            fromEvent(this.el.nativeElement, 'click').pipe(
+                // Delaying execution until after all other click callbacks
+                switchMap(() => fromEvent(this.el.nativeElement.parentElement!, 'click').pipe(take(1))),
+            ),
+        )
+            .pipe(
+                tap(() => {
+                    this.el.nativeElement.dispatchEvent(new CustomEvent(EVO_TAB_ACTIVATE, {bubbles: true}));
+                }),
+                takeUntil(this.destroy$),
+            )
+            .subscribe();
+    }
+}

--- a/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/evo-navigation-tabs.component.html
+++ b/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/evo-navigation-tabs.component.html
@@ -1,0 +1,22 @@
+<div class="evo-navigation-tabs" [attr.data-size]="size">
+    <ng-content select="[position=start]"></ng-content>
+
+    <ng-container *ngFor="let tab of tabs; let i = index">
+        <button
+            *ngIf="tab.link"
+            evoNavigationTab
+            routerLinkActive="active"
+            queryParamsHandling="merge"
+            [routerLink]="tab.link"
+            [routerLinkActiveOptions]="{exact: true}"
+            [disabled]="tab.disabled || disabled"
+        >
+            {{ tab.label }}
+        </button>
+        <button *ngIf="!tab.link" evoNavigationTab [disabled]="tab.disabled || disabled">
+            {{ tab.label }}
+        </button>
+    </ng-container>
+
+    <ng-content></ng-content>
+</div>

--- a/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/evo-navigation-tabs.component.scss
+++ b/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/evo-navigation-tabs.component.scss
@@ -1,0 +1,59 @@
+@import '../../styles/mixins.scss';
+
+:host {
+    display: block;
+}
+
+.evo-navigation-tabs {
+    display: flex;
+    box-shadow: inset 0 -1px 0 $color-disabled;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch; /* плавность на iOS */
+    scrollbar-width: none; /* Firefox */
+
+    &::-webkit-scrollbar {
+        display: none; /* Chrome/Safari */
+    }
+}
+
+.evo-navigation-tab {
+    display: flex;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 12px 16px;
+    border: none;
+    background: none;
+    color: $color-text;
+    white-space: nowrap;
+    text-transform: uppercase;
+    text-decoration: none;
+    cursor: pointer;
+    transition: all 0.3s;
+    @include evo-text-paragraph(p4);
+
+    .evo-navigation-tabs[data-size='small'] & {
+        padding: 7px 8px;
+        text-transform: none;
+        @include evo-text-caption(c1);
+    }
+
+    &:hover {
+        color: $color-primary;
+    }
+
+    &:focus-visible {
+        outline: none;
+    }
+
+    &._active:not(:disabled) {
+        color: $color-primary;
+        box-shadow: inset 0 -2px 0 $color-primary;
+        cursor: default;
+    }
+
+    &:disabled {
+        color: $color-disabled-text;
+        pointer-events: none;
+        cursor: default;
+    }
+}

--- a/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/evo-navigation-tabs.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/evo-navigation-tabs.component.ts
@@ -1,0 +1,125 @@
+import {
+    AfterViewChecked,
+    AfterViewInit,
+    ChangeDetectionStrategy,
+    Component,
+    ElementRef,
+    EventEmitter,
+    HostListener,
+    Input, OnDestroy,
+    Output,
+    ViewEncapsulation,
+} from '@angular/core';
+import {Subject} from 'rxjs';
+import { switchMap, take, takeUntil, tap } from 'rxjs/operators';
+import {EVO_TAB_ACTIVATE} from './evo-navigation-tab.directive';
+import {EvoTabsSize} from './types/evo-tabs-size';
+
+@Component({
+    selector: 'evo-navigation-tabs',
+    templateUrl: './evo-navigation-tabs.component.html',
+    styleUrls: ['./evo-navigation-tabs.component.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    encapsulation: ViewEncapsulation.None,
+})
+export class EvoNavigationTabsComponent implements AfterViewInit, AfterViewChecked, OnDestroy {
+    @Input() tabs: {label: string; link?: string; disabled?: boolean}[] = [];
+    @Input() size: EvoTabsSize = 'normal';
+    @Input('activeIndex') set setActiveIndex(index: number) {
+        this.activeIndex = index;
+        this.markTabAsActive();
+    }
+    @Input('disabled') set setDisabled(disabled: boolean) {
+        this.disabled = disabled;
+        this.disabledSubject$.next(disabled);
+    }
+
+    @Output() activeItemIndexChange = new EventEmitter<number>();
+
+    disabled = false;
+
+    private activeIndex = 0;
+
+    private readonly disabledSubject$ = new Subject<boolean>();
+    private readonly nextRenderSubject$ = new Subject<void>();
+    private readonly destroy$ = new Subject<void>();
+
+    constructor(private readonly el: ElementRef) {
+        this.initSubscriptions();
+    }
+
+    ngAfterViewInit(): void {
+        this.markTabAsActive();
+    }
+
+    ngAfterViewChecked(): void {
+        this.nextRenderSubject$.next();
+    }
+
+    ngOnDestroy(): void {
+        this.destroy$.next();
+        this.destroy$.complete();
+    }
+
+    @HostListener(EVO_TAB_ACTIVATE, ['$event', '$event.target'])
+    onActivate(event: Event, element: HTMLButtonElement): void {
+        const index = this.tabsList.findIndex((tab) => tab === element);
+
+        event.stopPropagation();
+
+        if (index === this.activeIndex) {
+            return;
+        }
+
+        this.activeItemIndexChange.emit(index);
+        this.activeIndex = index;
+        this.markTabAsActive();
+    }
+
+    private get tabsList(): readonly HTMLButtonElement[] {
+        return Array.from(this.el.nativeElement.querySelectorAll('[evoNavigationTab]'));
+    }
+
+    private get activeElement(): HTMLButtonElement | undefined {
+        return this.tabsList[this.activeIndex] || undefined;
+    }
+
+    private markTabAsActive(): void {
+        const {tabsList, activeElement} = this;
+
+        tabsList.forEach((nativeElement) => {
+            const active = nativeElement === activeElement;
+
+            nativeElement.classList.toggle('_active', active);
+            nativeElement.setAttribute('tabIndex', active ? '0' : '-1');
+        });
+    }
+
+    private markTabAsDisabled(): void {
+        this.tabsList.forEach((nativeElement) => {
+            const allDisabledClassName = '_all_disabled';
+
+            if (this.disabled && !nativeElement.disabled) {
+                nativeElement.classList.add(allDisabledClassName);
+                nativeElement.setAttribute('disabled', '');
+            }
+
+            if (!this.disabled && nativeElement.classList.contains(allDisabledClassName)) {
+                nativeElement.classList.remove(allDisabledClassName);
+                nativeElement.removeAttribute('disabled');
+            }
+        });
+    }
+
+    private initSubscriptions(): void {
+        this.disabledSubject$
+            .pipe(
+                switchMap(() => this.nextRenderSubject$.pipe(take(1))),
+                tap(() => {
+                    this.markTabAsDisabled();
+                }),
+                takeUntil(this.destroy$)
+            )
+            .subscribe();
+    }
+}

--- a/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/evo-navigation-tabs.module.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/evo-navigation-tabs.module.ts
@@ -1,0 +1,12 @@
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RouterModule} from '@angular/router';
+import {EvoNavigationTabsComponent} from './evo-navigation-tabs.component';
+import {EvoNavigationTabDirective} from './evo-navigation-tab.directive';
+
+@NgModule({
+    declarations: [EvoNavigationTabsComponent, EvoNavigationTabDirective],
+    imports: [CommonModule, RouterModule],
+    exports: [EvoNavigationTabsComponent, EvoNavigationTabDirective],
+})
+export class EvoNavigationTabsModule {}

--- a/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/evo-navigation-tabs.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/evo-navigation-tabs.spec.ts
@@ -1,0 +1,104 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {Component} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {EvoNavigationTabsComponent} from './evo-navigation-tabs.component';
+import {EVO_TAB_ACTIVATE} from './evo-navigation-tab.directive';
+
+@Component({
+    template: `
+        <evo-navigation-tabs
+            [tabs]="tabs"
+            [disabled]="disabled"
+            [activeIndex]="activeIndex"
+            (activeItemIndexChange)="onTabChange($event)"
+        ></evo-navigation-tabs>
+    `,
+})
+class TestHostComponent {
+    tabs = [{label: 'Tab 1'}, {label: 'Tab 2'}, {label: 'Tab 3', disabled: true}];
+    disabled = false;
+    activeIndex = 0;
+    selectedIndex: number | null = null;
+
+    onTabChange(index: number): void {
+        this.selectedIndex = index;
+    }
+}
+
+describe('EvoNavigationTabsComponent', () => {
+    let fixture: ComponentFixture<TestHostComponent>;
+    let hostComponent: TestHostComponent;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [EvoNavigationTabsComponent, TestHostComponent],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestHostComponent);
+        hostComponent = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create component', () => {
+        const component = fixture.debugElement.query(By.directive(EvoNavigationTabsComponent));
+        expect(component).toBeTruthy();
+    });
+
+    it('should render all provided tabs', () => {
+        const tabButtons = fixture.debugElement.nativeElement.querySelectorAll('[evoNavigationTab]');
+        expect(tabButtons.length).toBe(hostComponent.tabs.length);
+    });
+
+    it('should emit activeItemIndexChange when tab is activated', () => {
+        const mockEvent = new CustomEvent(EVO_TAB_ACTIVATE, {bubbles: true});
+        const buttons = fixture.nativeElement.querySelectorAll('[evoNavigationTab]');
+        let indexToActivate = 1;
+        spyOn(hostComponent, 'onTabChange');
+
+        buttons[indexToActivate].dispatchEvent(mockEvent);
+        fixture.detectChanges();
+
+        expect(hostComponent.onTabChange).toHaveBeenCalledWith(indexToActivate);
+    });
+
+    it('should set activeIndex via Input and apply _active class', () => {
+        hostComponent.activeIndex = 1;
+        fixture.detectChanges();
+
+        const buttons = fixture.nativeElement.querySelectorAll('[evoNavigationTab]');
+        expect(buttons[1].classList).toContain('_active');
+        expect(buttons[0].classList).not.toContain('_active');
+    });
+
+    it('should apply _all_disabled class and disable all tabs when disabled is true', () => {
+        hostComponent.disabled = true;
+        fixture.detectChanges();
+
+        const buttons: HTMLButtonElement[] = fixture.nativeElement.querySelectorAll('[evoNavigationTab]');
+        buttons.forEach((button: HTMLButtonElement) => {
+            expect(button.hasAttribute('disabled')).toBeTrue();
+        });
+    });
+
+    it('should have default size as normal', () => {
+        const componentInstance = fixture.debugElement.query(
+            By.directive(EvoNavigationTabsComponent),
+        ).componentInstance;
+        expect(componentInstance.size).toBe('normal');
+    });
+
+    it('should accept and set size input', () => {
+        const componentInstance = fixture.debugElement.query(
+            By.directive(EvoNavigationTabsComponent),
+        ).componentInstance;
+        componentInstance.size = 'compact';
+        fixture.detectChanges();
+        expect(componentInstance.size).toBe('compact');
+    });
+
+    it('should apply _active class to the selected tab', () => {
+        const buttons = fixture.nativeElement.querySelectorAll('[evoNavigationTab]');
+        const activeButton = buttons[hostComponent.activeIndex];
+        expect(activeButton.classList).toContain('_active');
+    });
+});

--- a/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/index.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/index.ts
@@ -1,0 +1,1 @@
+export * from './public-api';

--- a/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/public-api.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/public-api.ts
@@ -1,0 +1,4 @@
+export * from './evo-navigation-tabs.module';
+export * from './evo-navigation-tabs.component';
+export * from './evo-navigation-tab.directive';
+export * from "./types/evo-tabs-size";

--- a/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/types/evo-tabs-size.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-navigation-tabs/types/evo-tabs-size.ts
@@ -1,0 +1,1 @@
+export type EvoTabsSize = 'small' | 'normal';

--- a/projects/evo-ui-kit/src/lib/services/mutation-observer.service.ts
+++ b/projects/evo-ui-kit/src/lib/services/mutation-observer.service.ts
@@ -1,0 +1,59 @@
+import {ElementRef, inject, Injectable} from '@angular/core';
+import {Observable} from 'rxjs';
+
+/**
+ * Безопасная обёртка над `MutationObserver`, которая гарантирует,
+ * что код не упадёт в средах, где `MutationObserver` недоступен
+ * (например, серверный рендеринг или тесты без DOM).
+ *
+ * Если `MutationObserver` существует — используется он.
+ * Если нет — используется заглушка с пустыми методами.
+ */
+export const SafeObserver =
+    typeof MutationObserver !== 'undefined'
+        ? MutationObserver
+        : class implements MutationObserver {
+              observe(): void {}
+              disconnect(): void {}
+              takeRecords(): MutationRecord[] {
+                  return [];
+              }
+          };
+
+/**
+ * Сервис `MutationObserverService` предоставляет поток `Observable<MutationRecord[]>`,
+ * который эмитит записи изменений DOM для текущего элемента (`ElementRef`).
+ *
+ * Наблюдает за изменениями потомков, текстового содержимого и вложенных структур (`subtree: true`).
+ *
+ * Используется `SafeObserver`, чтобы гарантировать совместимость с SSR и тестовой средой.
+ *
+ * ⚠️ Важно: требует, чтобы `ElementRef` был доступен через DI-контекст (т.е. работает в компонентах/директивах).
+ *
+ * @example
+ * this.mutationObserverService.subscribe(records => {
+ *   console.log('Mutation detected!', records);
+ * });
+ */
+@Injectable()
+export class MutationObserverService extends Observable<readonly MutationRecord[]> {
+    constructor() {
+        const nativeElement: Node = inject(ElementRef).nativeElement;
+
+        super((subscriber) => {
+            const observer = new SafeObserver((records) => {
+                subscriber.next(records);
+            });
+
+            observer.observe(nativeElement, {
+                childList: true,
+                characterData: true,
+                subtree: true,
+            });
+
+            return () => {
+                observer.disconnect();
+            };
+        });
+    }
+}

--- a/projects/evo-ui-kit/src/lib/services/router-link-active.service.ts
+++ b/projects/evo-ui-kit/src/lib/services/router-link-active.service.ts
@@ -1,0 +1,34 @@
+import {Inject, Injectable, NgZone, Optional} from '@angular/core';
+import {RouterLinkActive} from '@angular/router';
+import {EMPTY, merge, Observable, timer} from 'rxjs';
+import {distinctUntilChanged, map} from 'rxjs/operators';
+import {ANIMATION_FRAME} from '../utils/tokens/animation-frame';
+import {evoZoneOptimized} from '../utils/observables/zone-free';
+
+/**
+ * Сервис создает поток, отслеживающий состояние активности
+ * `RouterLinkActive` в реальном времени с использованием `requestAnimationFrame`.
+ *
+ * Наследуется от `Observable<boolean>` и эмитит `true` или `false`, когда состояние `isActive`
+ * меняется. Если `RouterLinkActive` не передан — поток будет пустым (`EMPTY`).
+ */
+@Injectable()
+export class RouterLinkActiveService extends Observable<boolean> {
+    constructor(
+        @Optional()
+        @Inject(RouterLinkActive)
+        routerLinkActive: RouterLinkActive | null,
+        @Inject(NgZone) ngZone: NgZone,
+        @Inject(ANIMATION_FRAME) animationFrame$: Observable<number>,
+    ) {
+        const stream$ = routerLinkActive
+            ? merge(timer(0), animationFrame$).pipe(
+                  map(() => routerLinkActive.isActive),
+                  distinctUntilChanged(),
+                  evoZoneOptimized(ngZone),
+              )
+            : EMPTY;
+
+        super((subscriber) => stream$.subscribe(subscriber));
+    }
+}

--- a/projects/evo-ui-kit/src/lib/utils/observables/zone-free.ts
+++ b/projects/evo-ui-kit/src/lib/utils/observables/zone-free.ts
@@ -1,0 +1,71 @@
+import {NgZone} from '@angular/core';
+import {MonoTypeOperatorFunction, Observable, pipe} from 'rxjs';
+
+/**
+ * Кратко:
+ * 🔥 evoZonefull — тащит всё в Angular-зону.
+ * 🧊 evoZonefree — игнорирует Angular-зону, экономит CD.
+ * ⚖️ evoZoneOptimized — как утро с кофе: просыпаешься вовремя и не дергаешь лишний раз change detection.
+ */
+
+/**
+ * Оператор `evoZonefull` обеспечивает полное выполнение потока внутри зоны Angular.
+ *
+ * Все `next`, `error` и `complete` вызовы оборачиваются в `NgZone.run`, чтобы гарантировать
+ * корректный запуск change detection.
+ *
+ * Используй, если поток формируется вне зоны или ты не уверен, что Angular узнает об изменениях.
+ *
+ * @param zone Сервис `NgZone` из Angular DI.
+ * @returns Оператор, оборачивающий поток в `NgZone.run()`.
+ *
+ * @example
+ * source$.pipe(evoZonefull(this.ngZone)).subscribe(...);
+ */
+export function evoZonefull<T>(zone: NgZone): MonoTypeOperatorFunction<T> {
+    return (source) =>
+        new Observable((subscriber) =>
+            source.subscribe({
+                next: (value) => zone.run(() => subscriber.next(value)),
+                error: (error: unknown) => zone.run(() => subscriber.error(error)),
+                complete: () => zone.run(() => subscriber.complete()),
+            }),
+        );
+}
+
+/**
+ * Оператор `evoZonefree` исполняет весь поток вне зоны Angular.
+ *
+ * Это помогает избежать лишних срабатываний change detection и повысить производительность,
+ * особенно для часто испускаемых потоков (например, `scroll`, `animationFrame`, таймеры).
+ *
+ * Используй, если тебе не нужно обновлять Angular view внутри этого потока.
+ *
+ * @param zone Сервис `NgZone` из Angular DI.
+ * @returns Оператор, исполняющий подписку вне Angular-зоны.
+ *
+ * @example
+ * source$.pipe(evoZonefree(this.ngZone)).subscribe(...);
+ */
+export function evoZonefree<T>(zone: NgZone): MonoTypeOperatorFunction<T> {
+    return (source) => new Observable((subscriber) => zone.runOutsideAngular(() => source.subscribe(subscriber)));
+}
+
+/**
+ * Оператор `evoZoneOptimized` — комбо из `evoZonefree` и `evoZonefull`.
+ *
+ * Сначала поток исполняется вне Angular-зоны (`runOutsideAngular`), чтобы избежать лишнего
+ * change detection. Но события `next`, `error` и `complete` всё равно возвращаются в Angular-зону.
+ *
+ * Это идеальный баланс, если тебе нужен быстрый поток без лишнего CD, но ты всё равно хочешь,
+ * чтобы Angular знал о результатах.
+ *
+ * @param zone Сервис `NgZone` из Angular DI.
+ * @returns Оператор, оптимизированный по производительности.
+ *
+ * @example
+ * source$.pipe(evoZoneOptimized(this.ngZone)).subscribe(...);
+ */
+export function evoZoneOptimized<T>(zone: NgZone): MonoTypeOperatorFunction<T> {
+    return pipe(evoZonefree(zone), evoZonefull(zone));
+}

--- a/projects/evo-ui-kit/src/lib/utils/tokens/animation-frame.ts
+++ b/projects/evo-ui-kit/src/lib/utils/tokens/animation-frame.ts
@@ -1,0 +1,30 @@
+import {InjectionToken} from '@angular/core';
+import {Observable} from 'rxjs';
+import {share} from 'rxjs/operators';
+
+/**
+ * Токен `ANIMATION_FRAME` предоставляет поток значений времени из `requestAnimationFrame`,
+ * испускаемый каждый кадр анимации.
+ *
+ * Может быть полезен для задач, которые требуют частого обновления, например, отслеживания
+ * активности или плавной анимации в UI.
+ */
+export const ANIMATION_FRAME = new InjectionToken<Observable<DOMHighResTimeStamp>>('[ANIMATION_FRAME]', {
+    factory: () => {
+        const animationFrame$ = new Observable<DOMHighResTimeStamp>((subscriber) => {
+            let id = NaN;
+            const callback = (timestamp: DOMHighResTimeStamp): void => {
+                subscriber.next(timestamp);
+                id = requestAnimationFrame(callback);
+            };
+
+            id = requestAnimationFrame(callback);
+
+            return () => {
+                cancelAnimationFrame(id);
+            };
+        });
+
+        return animationFrame$.pipe(share());
+    },
+});

--- a/src/stories/components/evo-navigation-tabs.stories.ts
+++ b/src/stories/components/evo-navigation-tabs.stories.ts
@@ -1,0 +1,76 @@
+import {Meta, Story} from '@storybook/angular';
+import {moduleMetadata} from '@storybook/angular';
+import {CommonModule} from '@angular/common';
+import {Component} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {
+    EvoNavigationTabDirective,
+    EvoNavigationTabsComponent,
+    EvoTabsSize,
+} from '../../../projects/evo-ui-kit/src/lib/components/evo-navigation-tabs';
+
+export default {
+    title: 'Components/EvoNavigationTabs',
+    component: EvoNavigationTabsComponent,
+    decorators: [
+        moduleMetadata({
+            declarations: [EvoNavigationTabsComponent, EvoNavigationTabDirective],
+            imports: [CommonModule, FormsModule],
+        }),
+    ],
+} as Meta;
+
+const mockTabs = [{label: 'Tab 1'}, {label: 'Tab 2'}, {label: 'Tab 3', disabled: true}];
+
+@Component({
+    selector: 'storybook-ng-content-demo',
+    template: `
+        <evo-navigation-tabs
+            [tabs]="tabs"
+            [size]="size"
+            [activeIndex]="activeIndex"
+            (activeItemIndexChange)="onTabChange($event)"
+        >
+            <button evoNavigationTab position="start">📌 Custom content before tabs</button>
+            <button evoNavigationTab>💡 Additional content below</button>
+        </evo-navigation-tabs>
+
+        <br />
+        <div>
+            <div>index:</div>
+            <input type="number" [(ngModel)]="activeIndex" />
+        </div>
+        <br />
+        <div>
+            <div>size:</div>
+            <label>
+                <input type="radio" name="size" value="normal" checked (change)="onSizeChange('normal')" />
+                Normal
+            </label>
+
+            <label>
+                <input type="radio" name="size" value="small" (change)="onSizeChange('small')" />
+                Small
+            </label>
+        </div>
+    `,
+})
+class TabsDemoComponent {
+    tabs = mockTabs;
+    activeIndex = 0;
+    size: EvoTabsSize = 'normal';
+
+    onTabChange(index: number): void  {
+        this.activeIndex = index;
+    }
+
+    onSizeChange(size: EvoTabsSize): void {
+        this.size = size;
+        console.log('Selected size:', size);
+    }
+}
+
+export const Default: Story = () => ({
+    component: TabsDemoComponent,
+});
+Default.storyName = 'default';


### PR DESCRIPTION
Функциональность:

* принимает `size` = `small | normal`
* можно передать массив `tabs`
* можно передать `<ng-content>`
* можно передать оба варианта и `<ng-content>` расположить сверху или снизу массива `tabs`
* можно дизеблить отдельно каждый таб, или сразу все табы если были задизеблины некоторые табы и потом дизеблются все табы - дезебл табов происходит по остаточному принципу если дизебл с родителя снимается - разблокируются только ранее заблокированные (изначальные табы с дизебл остаются)
* табы поддерживают `RouterLinkActive`