### PR TITLE
MRK-4890: Компоненты: Добавить возможность закрытия тултипа при скролле (V7) 

### DIFF
--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/constants/evo-tooltip-config.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/constants/evo-tooltip-config.ts
@@ -3,4 +3,5 @@ import {EvoTooltipConfig} from '../interfaces/evo-tooltip-config';
 export const EVO_TOOLTIP_CONFIG: EvoTooltipConfig = {
     hideDelay: 300,
     showDelay: 100,
+    scrollStrategy: 'close',
 };

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/directives/evo-tooltip.directive.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/directives/evo-tooltip.directive.spec.ts
@@ -3,7 +3,7 @@ import { EvoTooltipDirective } from './evo-tooltip.directive';
 import { Component } from '@angular/core';
 import { EvoTooltipPosition } from '../enums/evo-tooltip-position';
 import { EvoTooltipStyles } from '../interfaces/evo-tooltip-styles';
-import { EvoTooltipVariableArrowPosition } from '../enums/evo-tooltip-variable-arrow-position';
+import { EvoTooltipStyleVariable } from '../enums/evo-tooltip-style-variable';
 import { CommonModule } from '@angular/common';
 import { EvoTooltipService } from '../services/evo-tooltip.service';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -32,8 +32,8 @@ class TestHostComponent {
     config = { showDelay: 0, hideDelay: 0 };
     visibleArrow = true;
     styles: EvoTooltipStyles = {
-        [EvoTooltipVariableArrowPosition.VERTICAL_POSITION_ARROW]: '10px',
-        [EvoTooltipVariableArrowPosition.HORIZONTAL_POSITION_ARROW]: '20px',
+        [EvoTooltipStyleVariable.VERTICAL_POSITION_ARROW]: '10px',
+        [EvoTooltipStyleVariable.HORIZONTAL_POSITION_ARROW]: '20px',
     };
     classes = ['class-1', 'class-2'];
     onOpen = jasmine.createSpy('onOpen');
@@ -117,6 +117,16 @@ describe('EvoTooltipDirective', () => {
         tick(0);
         fixture.detectChanges();
         tooltipService.isOpen$.pipe(first()).subscribe(isOpen => {
+            expect(isOpen).toBeTrue();
+        });
+    }));
+
+    it('should handle touchstart event', fakeAsync(() => {
+        const element = fixture.debugElement.children[0].nativeElement;
+        element.dispatchEvent(new MouseEvent('touchstart'));
+        tick(0);
+        fixture.detectChanges();
+        tooltipService.isOpen$.pipe(first()).subscribe((isOpen) => {
             expect(isOpen).toBeTrue();
         });
     }));

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/directives/evo-tooltip.directive.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/directives/evo-tooltip.directive.ts
@@ -9,8 +9,8 @@ import {
     Output,
     TemplateRef,
 } from '@angular/core';
-import {EMPTY, filter, fromEvent, merge, Subject} from 'rxjs';
-import {catchError, debounceTime, distinctUntilChanged, first, map, takeUntil, tap, throttleTime} from 'rxjs/operators';
+import {EMPTY, fromEvent, merge, Subject} from 'rxjs';
+import {catchError, debounceTime, distinctUntilChanged, filter, first, map, takeUntil, tap, throttleTime} from 'rxjs/operators';
 import {EVO_TOOLTIP_CONFIG} from '../constants/evo-tooltip-config';
 import {EvoTooltipPosition} from '../enums/evo-tooltip-position';
 import {EvoTooltipConfig} from '../interfaces/evo-tooltip-config';

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/directives/evo-tooltip.directive.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/directives/evo-tooltip.directive.ts
@@ -118,10 +118,13 @@ export class EvoTooltipDirective implements OnInit, OnDestroy {
                     this.tooltipService.hideTooltip();
                     return EMPTY;
                 }),
-                takeUntil(this.destroy$),
+                takeUntil(merge(
+                    this.destroy$,
+                    this.tooltipService.isOpen$.pipe(
+                        filter((isOpened: boolean) => !isOpened)
+                    )
+                )),
             )
-            .subscribe(() => {
-                this.tooltipService.hideTooltip();
-            });
+            .subscribe(() => this.tooltipService.hideTooltip());
     }
 }

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/directives/evo-tooltip.directive.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/directives/evo-tooltip.directive.ts
@@ -9,14 +9,14 @@ import {
     Output,
     TemplateRef,
 } from '@angular/core';
-import {fromEvent, merge, Observable, Subject} from 'rxjs';
-import {takeUntil, tap, throttleTime} from 'rxjs/operators';
-import {EvoTooltipService} from '../services/evo-tooltip.service';
-import {EvoTooltipPositionType} from '../types/evo-tooltip-position-type';
-import {EvoTooltipConfig} from '../interfaces/evo-tooltip-config';
+import {EMPTY, filter, fromEvent, merge, Subject} from 'rxjs';
+import {catchError, debounceTime, distinctUntilChanged, first, map, takeUntil, tap, throttleTime} from 'rxjs/operators';
 import {EVO_TOOLTIP_CONFIG} from '../constants/evo-tooltip-config';
 import {EvoTooltipPosition} from '../enums/evo-tooltip-position';
+import {EvoTooltipConfig} from '../interfaces/evo-tooltip-config';
 import {EvoTooltipStyles} from '../interfaces/evo-tooltip-styles';
+import {EvoTooltipService} from '../services/evo-tooltip.service';
+import {EvoTooltipPositionType} from '../types/evo-tooltip-position-type';
 
 @Directive({
     selector: '[evoTooltip]',
@@ -45,8 +45,6 @@ export class EvoTooltipDirective implements OnInit, OnDestroy {
         return ['evo-tooltip-trigger', ...(this.disabled ? ['evo-tooltip-trigger_disabled'] : [])];
     }
 
-    readonly isOpen$: Observable<boolean> = this.tooltipService.isOpen$;
-
     private readonly destroy$ = new Subject<void>();
 
     constructor(private readonly elementRef: ElementRef, private readonly tooltipService: EvoTooltipService) {}
@@ -65,18 +63,19 @@ export class EvoTooltipDirective implements OnInit, OnDestroy {
         this.tooltipService.hideTooltip();
     }
 
-    show(event?: MouseEvent): void {
+    show(): void {
         if (!this.content || this.tooltipService.hasAttached || this.disabled) {
             return;
         }
 
-        this.tooltipService.showTooltip(
+        const tooltip = this.tooltipService.showTooltip(
             this.elementRef,
             this.content,
             this.position as EvoTooltipPosition,
             {...EVO_TOOLTIP_CONFIG, ...this.config},
-            event?.target,
         );
+
+        this.initHideSubscription(tooltip);
     }
 
     private initSubscriptions(): void {
@@ -85,20 +84,44 @@ export class EvoTooltipDirective implements OnInit, OnDestroy {
         merge(fromEvent(element, 'mouseenter'), fromEvent(element, 'touchstart'))
             .pipe(
                 throttleTime(this.config?.showDelay ?? EVO_TOOLTIP_CONFIG.showDelay),
-                tap(() => {
-                    this.show();
-                }),
+                tap(() => this.show()),
                 takeUntil(this.destroy$),
             )
             .subscribe();
 
         this.tooltipService.isOpen$
             .pipe(
+                distinctUntilChanged(),
                 tap((isOpen) => {
-                    isOpen ? this.evoTooltipOpen.emit() : this.evoTooltipClose.emit();
+                    if (isOpen) {
+                        this.evoTooltipOpen.emit();
+                    } else {
+                        this.evoTooltipClose.emit();
+                    }
                 }),
                 takeUntil(this.destroy$),
             )
             .subscribe();
+    }
+
+    private initHideSubscription(tooltip: HTMLElement): void {
+        const mouseLeaveParentElement$ = fromEvent(tooltip, 'mouseleave').pipe(map(() => this.elementRef.nativeElement));
+        const mouseLeaveOverlayElement$ = fromEvent(this.elementRef.nativeElement, 'mouseleave').pipe(map(() => tooltip));
+
+        merge(mouseLeaveParentElement$, mouseLeaveOverlayElement$)
+            .pipe(
+                filter((element) => !element.matches(':hover')),
+                debounceTime(this.config?.hideDelay ?? EVO_TOOLTIP_CONFIG.hideDelay),
+                filter(() => !tooltip.matches(':hover') && !this.elementRef.nativeElement.matches(':hover')),
+                first(),
+                catchError(() => {
+                    this.tooltipService.hideTooltip();
+                    return EMPTY;
+                }),
+                takeUntil(this.destroy$),
+            )
+            .subscribe(() => {
+                this.tooltipService.hideTooltip();
+            });
     }
 }

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/directives/evo-tooltip.directive.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/directives/evo-tooltip.directive.ts
@@ -9,7 +9,7 @@ import {
     Output,
     TemplateRef,
 } from '@angular/core';
-import {fromEvent, Observable, Subject} from 'rxjs';
+import {fromEvent, merge, Observable, Subject} from 'rxjs';
 import {takeUntil, tap, throttleTime} from 'rxjs/operators';
 import {EvoTooltipService} from '../services/evo-tooltip.service';
 import {EvoTooltipPositionType} from '../types/evo-tooltip-position-type';
@@ -80,7 +80,9 @@ export class EvoTooltipDirective implements OnInit, OnDestroy {
     }
 
     private initSubscriptions(): void {
-        fromEvent(this.elementRef.nativeElement, 'mouseenter')
+        const element = this.elementRef.nativeElement;
+
+        merge(fromEvent(element, 'mouseenter'), fromEvent(element, 'touchstart'))
             .pipe(
                 throttleTime(this.config?.showDelay ?? EVO_TOOLTIP_CONFIG.showDelay),
                 tap(() => {

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/enums/evo-tooltip-style-variable.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/enums/evo-tooltip-style-variable.ts
@@ -1,0 +1,12 @@
+export enum EvoTooltipStyleVariable {
+    HORIZONTAL_POSITION_ARROW = '--evo-tooltip-horizontal-position-arrow',
+    VERTICAL_POSITION_ARROW = '--evo-tooltip-vertical-position-arrow',
+
+    COLOR = '--evo-tooltip-color',
+    BACKGROUND_COLOR = '--evo-tooltip-background-color',
+    MAX_WIDTH = '--evo-tooltip-max-width',
+
+    PADDING = '--evo-tooltip-padding',
+
+    BORDER_RADIUS = '--evo-tooltip-border-radius',
+}

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/enums/evo-tooltip-variable-arrow-position.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/enums/evo-tooltip-variable-arrow-position.ts
@@ -1,4 +1,0 @@
-export enum EvoTooltipVariableArrowPosition {
-    HORIZONTAL_POSITION_ARROW = '--evo-tooltip-horizontal-position-arrow',
-    VERTICAL_POSITION_ARROW = '--evo-tooltip-vertical-position-arrow',
-}

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/evo-tooltip.component.scss
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/evo-tooltip.component.scss
@@ -1,4 +1,4 @@
-@import '../../styles/mixins';
+@import "../../styles/mixins";
 
 :host {
     --evo-tooltip-horizontal-position-arrow: 50%;
@@ -15,8 +15,6 @@
 }
 
 .evo-tooltip {
-    $arrow-size: 8px;
-
     display: inline-block;
     position: relative;
     background-color: var(--evo-tooltip-background-color);
@@ -39,34 +37,19 @@
         content: "";
         position: absolute;
         border-style: solid;
+        left: var(--evo-tooltip-horizontal-position-arrow);
+        top: var(--evo-tooltip-vertical-position-arrow);
+        width: 0;
+        height: 0;
+        border-width: 0 8px 8px 8px;
+        border-color: transparent transparent var(--evo-tooltip-background-color) transparent;
     }
 
     &_top-start,
     &_top,
     &_top-end {
         &:before {
-            border-width: $arrow-size $arrow-size 0 $arrow-size;
-            border-color: var(--evo-tooltip-background-color) transparent transparent transparent;
-            bottom: -$arrow-size;
-        }
-    }
-
-    &_top-start {
-        &:before {
-            left: var(--evo-tooltip-horizontal-position-arrow);
-        }
-    }
-
-    &_top {
-        &:before {
-            left: 50%;
-            transform: translateX(-50%);
-        }
-    }
-
-    &_top-end {
-        &:before {
-            right: var(--evo-tooltip-horizontal-position-arrow);
+            transform: rotate(180deg);
         }
     }
 
@@ -74,28 +57,7 @@
     &_right,
     &_right-end {
         &:before {
-            border-width: $arrow-size $arrow-size $arrow-size 0;
-            border-color: transparent var(--evo-tooltip-background-color) transparent transparent;
-            left: -$arrow-size;
-        }
-    }
-
-    &_right-start {
-        &:before {
-            top: var(--evo-tooltip-vertical-position-arrow);
-        }
-    }
-
-    &_right {
-        &:before {
-            top: 50%;
-            transform: translateY(-50%);
-        }
-    }
-
-    &_right-end {
-        &:before {
-            bottom: var(--evo-tooltip-vertical-position-arrow);
+            transform: rotate(-90deg) translateX(-4px) translateY(-12px);
         }
     }
 
@@ -103,28 +65,7 @@
     &_bottom,
     &_bottom-end {
         &:before {
-            border-width: 0 $arrow-size $arrow-size $arrow-size;
-            border-color: transparent transparent var(--evo-tooltip-background-color) transparent;
-            top: -$arrow-size;
-        }
-    }
-
-    &_bottom-start {
-        &:before {
-            left: var(--evo-tooltip-horizontal-position-arrow);
-        }
-    }
-
-    &_bottom {
-        &:before {
-            left: 50%;
-            transform: translateX(-50%);
-        }
-    }
-
-    &_bottom-end {
-        &:before {
-            right: var(--evo-tooltip-horizontal-position-arrow);
+            transform: translateY(-8px);
         }
     }
 
@@ -132,28 +73,7 @@
     &_left,
     &_left-end {
         &:before {
-            border-width: $arrow-size 0 $arrow-size $arrow-size;
-            border-color: transparent transparent transparent var(--evo-tooltip-background-color);
-            right: -$arrow-size;
-        }
-    }
-
-    &_left-start {
-        &:before {
-            top: var(--evo-tooltip-vertical-position-arrow);
-        }
-    }
-
-    &_left {
-        &:before {
-            top: 50%;
-            transform: translateY(-50%);
-        }
-    }
-
-    &_left-end {
-        &:before {
-            bottom: var(--evo-tooltip-vertical-position-arrow);
+            transform: rotate(90deg) translateX(4px) translateY(4px);
         }
     }
 }

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/evo-tooltip.component.scss
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/evo-tooltip.component.scss
@@ -15,6 +15,8 @@
 }
 
 .evo-tooltip {
+    $arrow-border-width: 8px;
+
     display: inline-block;
     position: relative;
     background-color: var(--evo-tooltip-background-color);
@@ -36,28 +38,19 @@
     &:not(&_not-arrow):before {
         content: "";
         position: absolute;
-        border-style: solid;
         left: var(--evo-tooltip-horizontal-position-arrow);
         top: var(--evo-tooltip-vertical-position-arrow);
         width: 0;
         height: 0;
-        border-width: 0 8px 8px 8px;
-        border-color: transparent transparent var(--evo-tooltip-background-color) transparent;
-    }
-
-    &_top-start,
-    &_top,
-    &_top-end {
-        &:before {
-            transform: rotate(180deg);
-        }
+        border: $arrow-border-width solid transparent;
+        border-top: $arrow-border-width solid var(--evo-tooltip-background-color);
     }
 
     &_right-start,
     &_right,
     &_right-end {
         &:before {
-            transform: rotate(-90deg) translateX(-4px) translateY(-12px);
+            transform: rotate(90deg);
         }
     }
 
@@ -65,7 +58,7 @@
     &_bottom,
     &_bottom-end {
         &:before {
-            transform: translateY(-8px);
+            transform: rotate(180deg);
         }
     }
 
@@ -73,7 +66,7 @@
     &_left,
     &_left-end {
         &:before {
-            transform: rotate(90deg) translateX(4px) translateY(4px);
+            transform: rotate(-90deg);
         }
     }
 }

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/evo-tooltip.component.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/evo-tooltip.component.spec.ts
@@ -1,16 +1,17 @@
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {EvoTooltipComponent} from './evo-tooltip.component';
 import {EvoTooltipService} from './services/evo-tooltip.service';
-import {NO_ERRORS_SCHEMA, Component, ViewChild, TemplateRef} from '@angular/core';
+import {Component, ElementRef, NO_ERRORS_SCHEMA, TemplateRef, ViewChild} from '@angular/core';
 import {EvoTooltipPosition} from './enums/evo-tooltip-position';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {EvoTooltipStyles} from './interfaces/evo-tooltip-styles';
-import {EvoTooltipVariableArrowPosition} from './enums/evo-tooltip-variable-arrow-position';
+import {EvoTooltipStyleVariable} from './enums/evo-tooltip-style-variable';
 import {CommonModule} from '@angular/common';
 
 @Component({
     selector: 'evo-host-component',
     template: `
+        <div #tooltipParent>Parent</div>
         <evo-tooltip></evo-tooltip>
         <ng-template #testTemplate>
             <div>Test template content</div>
@@ -20,6 +21,7 @@ import {CommonModule} from '@angular/common';
 class TestHostComponent {
     @ViewChild(EvoTooltipComponent, {static: true}) tooltipComponent: EvoTooltipComponent;
     @ViewChild('testTemplate', {static: true}) testTemplate: TemplateRef<any>;
+    @ViewChild('tooltipParent', {static: true}) parentRef: ElementRef
 }
 
 describe('EvoTooltipComponent', () => {
@@ -44,6 +46,7 @@ describe('EvoTooltipComponent', () => {
         testHostComponent = testHostFixture.componentInstance;
         tooltipComponent = testHostComponent.tooltipComponent;
         tooltipService = TestBed.inject(EvoTooltipService);
+        tooltipService['_parentRef$'].next(testHostComponent.parentRef);
         testHostFixture.detectChanges();
     });
 
@@ -83,14 +86,14 @@ describe('EvoTooltipComponent', () => {
 
     it('should update styles when styles$ changes', () => {
         const styles: EvoTooltipStyles = {
-            [EvoTooltipVariableArrowPosition.VERTICAL_POSITION_ARROW]: '10px',
-            [EvoTooltipVariableArrowPosition.HORIZONTAL_POSITION_ARROW]: '20px',
+            [EvoTooltipStyleVariable.MAX_WIDTH]: 'auto',
+            [EvoTooltipStyleVariable.PADDING]: 0,
         };
         tooltipService['_styles$'].next(styles);
         testHostFixture.detectChanges();
 
         tooltipComponent.styles$.subscribe((value) => {
-            expect(value).toEqual(styles);
+            Object.keys(styles).forEach((key: string) => expect(value[key]).toEqual(styles[key]));
         });
     });
 

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/evo-tooltip.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/evo-tooltip.component.ts
@@ -15,8 +15,9 @@ import {EVO_TOOLTIP_FADEIN_ANIMATION} from './constants/evo-tooltip-fadein.anima
 import {EvoTooltipService} from './services/evo-tooltip.service';
 import {EvoTooltipStyles} from './interfaces/evo-tooltip-styles';
 import {EvoTooltipPosition} from './enums/evo-tooltip-position';
+import {EvoTooltipStyleVariable} from './enums/evo-tooltip-style-variable';
+import {EVO_TOOLTIP_RADIUS} from './constants/evo-tooltip-radius';
 import {EVO_TOOLTIP_ARROW_SIZE} from './constants/evo-tooltip-arrow-size';
-import {EvoTooltipVariableArrowPosition} from './enums/evo-tooltip-variable-arrow-position';
 
 @Component({
     selector: 'evo-tooltip',
@@ -86,22 +87,37 @@ export class EvoTooltipComponent implements OnInit, AfterViewInit, OnDestroy {
         tooltipEnd: number;
     }): number {
         const tooltipSize = params.tooltipEnd - params.tooltipStart;
+        const parentSize = params.parentEnd - params.parentStart;
 
-        if (params.parentEnd <= params.tooltipStart) {
-            return 0;
+        // tooltip after the parent
+        if (params.parentEnd < params.tooltipStart) {
+            return -EVO_TOOLTIP_ARROW_SIZE;
         }
 
-        if (params.parentStart >= params.tooltipEnd) {
+        // tooltip before the parent
+        if (params.parentStart > params.tooltipEnd) {
             return tooltipSize;
         }
 
-        const parentSize = params.parentEnd - params.parentStart;
+        const tooltipCenter = Math.round(tooltipSize / 2);
+        const parentCenterOnTooltip = Math.round(parentSize / 2 + params.parentStart - params.tooltipStart);
 
-        const parentMiddleOffset = params.parentStart + parentSize / 2;
-        const elementMiddleOffset = params.tooltipStart + tooltipSize / 2;
+        const defaultArrowOffset = parentCenterOnTooltip - EVO_TOOLTIP_ARROW_SIZE / 2;
 
-        const diff = elementMiddleOffset - parentMiddleOffset;
-        return elementMiddleOffset - diff - params.tooltipStart - EVO_TOOLTIP_ARROW_SIZE / 2;
+        // centers are is one positions
+        if (tooltipCenter === parentCenterOnTooltip) {
+            return defaultArrowOffset;
+        }
+
+        const minPosition = EVO_TOOLTIP_RADIUS;
+        const maxPosition = tooltipSize - EVO_TOOLTIP_ARROW_SIZE - EVO_TOOLTIP_RADIUS;
+
+        // parent center inside tooltip
+        if (defaultArrowOffset >= minPosition && parentCenterOnTooltip <= maxPosition) {
+            return defaultArrowOffset;
+        }
+
+        return tooltipCenter > parentCenterOnTooltip ? minPosition : maxPosition;
     }
 
     private setArrowPosition(parentRef: ElementRef): void {
@@ -123,8 +139,8 @@ export class EvoTooltipComponent implements OnInit, AfterViewInit, OnDestroy {
         });
 
         this._positionArrowStyles$.next({
-            [EvoTooltipVariableArrowPosition.VERTICAL_POSITION_ARROW]: `${vertical}px`,
-            [EvoTooltipVariableArrowPosition.HORIZONTAL_POSITION_ARROW]: `${horizontal}px`,
+            [EvoTooltipStyleVariable.VERTICAL_POSITION_ARROW]: `${vertical}px`,
+            [EvoTooltipStyleVariable.HORIZONTAL_POSITION_ARROW]: `${horizontal}px`,
         });
     }
 }

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/evo-tooltip.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/evo-tooltip.component.ts
@@ -11,13 +11,13 @@ import {
 } from '@angular/core';
 import {BehaviorSubject, combineLatest, EMPTY, Observable, Subject} from 'rxjs';
 import {filter, map, pairwise, startWith, takeUntil, tap} from 'rxjs/operators';
+import {EVO_TOOLTIP_ARROW_SIZE} from './constants/evo-tooltip-arrow-size';
 import {EVO_TOOLTIP_FADEIN_ANIMATION} from './constants/evo-tooltip-fadein.animation';
-import {EvoTooltipService} from './services/evo-tooltip.service';
-import {EvoTooltipStyles} from './interfaces/evo-tooltip-styles';
+import {EVO_TOOLTIP_RADIUS} from './constants/evo-tooltip-radius';
 import {EvoTooltipPosition} from './enums/evo-tooltip-position';
 import {EvoTooltipStyleVariable} from './enums/evo-tooltip-style-variable';
-import {EVO_TOOLTIP_RADIUS} from './constants/evo-tooltip-radius';
-import {EVO_TOOLTIP_ARROW_SIZE} from './constants/evo-tooltip-arrow-size';
+import {EvoTooltipStyles} from './interfaces/evo-tooltip-styles';
+import {EvoTooltipService} from './services/evo-tooltip.service';
 
 @Component({
     selector: 'evo-tooltip',
@@ -52,9 +52,7 @@ export class EvoTooltipComponent implements OnInit, AfterViewInit, OnDestroy {
         combineLatest([this.position$, this.tooltipService.parentRef$, this.visibleArrow$])
             .pipe(
                 filter(([_position, _parentRef, visibleArrow]) => visibleArrow),
-                tap(([_, parentRef]) => {
-                    this.setArrowPosition(parentRef);
-                }),
+                tap(([_, parentRef]) => this.setArrowPosition(parentRef)),
                 takeUntil(this._destroy$),
             )
             .subscribe();

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/interfaces/evo-tooltip-config.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/interfaces/evo-tooltip-config.ts
@@ -1,5 +1,8 @@
+import {EvoTooltipScrollStrategy} from '../types/evo-tooltip-scroll-strategy';
+
 export interface EvoTooltipConfig {
     // The default delay in ms before hiding the tooltip
     hideDelay?: number;
     showDelay?: number;
+    scrollStrategy?: EvoTooltipScrollStrategy;
 }

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/interfaces/evo-tooltip-styles.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/interfaces/evo-tooltip-styles.ts
@@ -1,5 +1,14 @@
-import {EvoTooltipVariableArrowPosition} from '../enums/evo-tooltip-variable-arrow-position';
+import {EvoTooltipStyleVariable} from '../enums/evo-tooltip-style-variable';
 
-export type EvoTooltipStyles = {
-    [key in EvoTooltipVariableArrowPosition]: string;
+export interface EvoTooltipStyles  {
+    [EvoTooltipStyleVariable.HORIZONTAL_POSITION_ARROW]?: string;
+    [EvoTooltipStyleVariable.VERTICAL_POSITION_ARROW]?: string;
+
+    [EvoTooltipStyleVariable.COLOR]?: string;
+    [EvoTooltipStyleVariable.BACKGROUND_COLOR]?: string;
+
+    [EvoTooltipStyleVariable.MAX_WIDTH]?: string | number;
+
+    [EvoTooltipStyleVariable.PADDING]?: string | number;
+    [EvoTooltipStyleVariable.BORDER_RADIUS]?: string | number;
 };

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/public-api.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/public-api.ts
@@ -1,6 +1,7 @@
 export * from './evo-tooltip.module';
 export * from './directives/evo-tooltip.directive';
 export * from './types/evo-tooltip-position-type';
+export * from './enums/evo-tooltip-position';
 export * from './interfaces/evo-tooltip-config';
 export * from './interfaces/evo-tooltip-styles';
 export * from './services/evo-tooltip.service';

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/public-api.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/public-api.ts
@@ -3,3 +3,4 @@ export * from './directives/evo-tooltip.directive';
 export * from './types/evo-tooltip-position-type';
 export * from './interfaces/evo-tooltip-config';
 export * from './interfaces/evo-tooltip-styles';
+export * from './services/evo-tooltip.service';

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/public-api.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/public-api.ts
@@ -1,2 +1,5 @@
 export * from './evo-tooltip.module';
 export * from './directives/evo-tooltip.directive';
+export * from './types/evo-tooltip-position-type';
+export * from './interfaces/evo-tooltip-config';
+export * from './interfaces/evo-tooltip-styles';

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/services/evo-tooltip.service.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/services/evo-tooltip.service.spec.ts
@@ -4,7 +4,7 @@ import {EvoTooltipPosition} from '../enums/evo-tooltip-position';
 import {EvoTooltipStyles} from '../interfaces/evo-tooltip-styles';
 import {ElementRef} from '@angular/core';
 import {first} from 'rxjs/operators';
-import {EvoTooltipVariableArrowPosition} from '../enums/evo-tooltip-variable-arrow-position';
+import {EvoTooltipStyleVariable} from '../enums/evo-tooltip-style-variable';
 import {CommonModule} from '@angular/common';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {EvoTooltipComponent} from '../evo-tooltip.component';
@@ -46,8 +46,8 @@ describe('EvoTooltipService', () => {
 
     it('should set tooltip styles', () => {
         const styles: EvoTooltipStyles = {
-            [EvoTooltipVariableArrowPosition.VERTICAL_POSITION_ARROW]: '10px',
-            [EvoTooltipVariableArrowPosition.HORIZONTAL_POSITION_ARROW]: '20px',
+            [EvoTooltipStyleVariable.VERTICAL_POSITION_ARROW]: '10px',
+            [EvoTooltipStyleVariable.HORIZONTAL_POSITION_ARROW]: '20px',
         };
         service.setTooltipStyles(styles);
         service.styles$.pipe(first()).subscribe((value) => {

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/services/evo-tooltip.service.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/services/evo-tooltip.service.ts
@@ -17,9 +17,9 @@ import {EVO_CONNECTED_POSITION} from '../constants/evo-tooltip-connected-positio
 import {EVO_PRIORITY_POSITIONS_ORDER} from '../constants/evo-tooltip-priority-positions-order';
 import {EVO_DEFAULT_POSITIONS_ORDER} from '../constants/evo-tooltip-default-positions-order';
 import {EVO_TOOLTIP_ARROW_SIZE} from '../constants/evo-tooltip-arrow-size';
-import {EVO_TOOLTIP_RADIUS} from '../constants/evo-tooltip-radius';
 import {EvoTooltipStyles} from '../interfaces/evo-tooltip-styles';
 import {EVO_TOOLTIP_OFFSET} from '../constants/evo-tooltip-offset';
+import {EVO_TOOLTIP_RADIUS} from '../constants/evo-tooltip-radius';
 
 @Injectable()
 export class EvoTooltipService {

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/services/evo-tooltip.service.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/services/evo-tooltip.service.ts
@@ -135,7 +135,9 @@ export class EvoTooltipService {
             .flexibleConnectedTo(elementRef)
             .withPositions(this.getPositions(position));
 
-        const scrollStrategy = this.overlay.scrollStrategies.reposition();
+        const scrollStrategy = this.overlay.scrollStrategies.close({
+            threshold: 10,
+        });
         this.overlayRef = this.overlay.create({positionStrategy: this.positionStrategy, scrollStrategy});
     }
 

--- a/projects/evo-ui-kit/src/lib/components/evo-tooltip/types/evo-tooltip-scroll-strategy.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tooltip/types/evo-tooltip-scroll-strategy.ts
@@ -1,0 +1,1 @@
+export type EvoTooltipScrollStrategy = 'noop' | 'close' | 'reposition' | 'block';

--- a/src/stories/components/evo-tooltip.stories.ts
+++ b/src/stories/components/evo-tooltip.stories.ts
@@ -1,0 +1,96 @@
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {EvoButtonModule, EvoTooltipModule, EvoTooltipPosition} from '@evotor-dev/ui-kit';
+import {moduleMetadata} from '@storybook/angular';
+
+export default {
+    title: 'Components/Tooltip',
+
+    decorators: [
+        moduleMetadata({
+            imports: [EvoTooltipModule, EvoButtonModule, BrowserAnimationsModule],
+        }),
+    ],
+};
+
+const POSITIONS_LIST: EvoTooltipPosition[] = [
+    EvoTooltipPosition.TOP_START,
+    EvoTooltipPosition.TOP,
+    EvoTooltipPosition.TOP_END,
+
+    EvoTooltipPosition.BOTTOM_START,
+    EvoTooltipPosition.BOTTOM,
+    EvoTooltipPosition.BOTTOM_END,
+
+    EvoTooltipPosition.RIGHT_START,
+    EvoTooltipPosition.RIGHT,
+    EvoTooltipPosition.RIGHT_END,
+
+    EvoTooltipPosition.LEFT_START,
+    EvoTooltipPosition.LEFT,
+    EvoTooltipPosition.LEFT_END,
+];
+
+export const Default = () => ({
+    template: `
+        <style>
+            .tooltip-story {
+                display: flex;
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 40px;            
+            }
+            
+            .tooltip-story__list {
+                display: grid;
+                grid-template-columns: max-content;
+                
+                gap: 16px;
+                align-self: center;
+                
+                @media (min-width: 768px){
+                    grid-template-columns: repeat(2, 280px);
+                }
+                
+                @media (min-width: 920px){
+                    grid-template-columns: repeat(3, 280px);
+                }
+            }
+            
+            .tooltip-story__list-item {
+                display: flex;
+                flex-direction: column;
+                gap: 16px;  
+                padding: 16px;
+                border-radius: 8px;
+                border: 1px solid #C6C6C6;
+                cursor: pointer;
+            }
+        </style>
+        <div class="tooltip-story">
+            <button evoButton (click)="isDisabled = !isDisabled">{{isDisabled ? ' Enable' : 'Disable'}} tooltips</button>
+            
+            <ul class="tooltip-story__list">
+                <li
+                    *ngFor="let item of POSITIONS_LIST"
+                    class="tooltip-story__list-item"
+                    [evoTooltip]="tooltipBodyTemplate"
+                    [evoTooltipPosition]="item"
+                    [evoTooltipDisabled]="isDisabled"
+                >
+                    <h4 class="evo-text-header evo-text-header_h4">{{item | titlecase }}</h4>
+                    <p>Tooltip parent with some content. Lorem ipsum dolor sit</p>
+                </li>
+            </ul>
+            
+            <ng-template #tooltipBodyTemplate>
+                Some tooltip content
+            </ng-template>
+        </div>
+    `,
+    props: {
+        POSITIONS_LIST: POSITIONS_LIST,
+        isDisabled: false
+    }
+});
+
+Default.storyName = 'default';


### PR DESCRIPTION
1) Добавлена обработка события touchstart, чтобы тултип открывался с мобилы (для iphone)

2) Исправлена логика позиционирования стрелочки тултипа

<img width="1080" height="411" alt="image-2025-07-21-10-32-07-931" src="https://github.com/user-attachments/assets/99dd152f-02b8-4ad9-839a-c550d16ff331" />

3) Перенес подписку, которая закрывает тултип из сервиса в директиву

4) Добавил в конфиг тултипа разные стратегии, а в сервисе тултипа добавил их обработку (noop, scrool, block, reposition). В изначальной реализации дефолтная стратегия была - reposition. Сейчас close