### PR TITLE
feat(evo-tabs): allow configuring active link matching

### DIFF
--- a/projects/evo-ui-kit/src/lib/components/evo-tabs/evo-tab/evo-tab.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tabs/evo-tab/evo-tab.component.ts
@@ -17,6 +17,7 @@ import {EvoUiClassDirective} from '../../../directives/evo-ui-class.directive';
 })
 export class EvoTabComponent implements OnInit, AfterViewInit, OnDestroy {
     @Input() name: string;
+    @Input() activeMatchOptions = true;
 
     selected = false;
     size = this.sizeService.size;
@@ -68,7 +69,11 @@ export class EvoTabComponent implements OnInit, AfterViewInit, OnDestroy {
 
     private initByUrl(): void {
         const urlTree = this.routerLink?.urlTree || this.routerLinkWithHref?.urlTree;
-        if (!(urlTree && this.router.isActive(urlTree, true))) {
+        if (!urlTree) {
+            return;
+        }
+
+        if (!this.router.isActive(urlTree, this.activeMatchOptions)) {
             return;
         }
         this.setTabActive();

--- a/projects/evo-ui-kit/src/lib/components/evo-tabs/evo-tab/evo-tab.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tabs/evo-tab/evo-tab.component.ts
@@ -2,7 +2,7 @@ import {AfterViewInit, ChangeDetectorRef, Component, Input, OnDestroy, OnInit, O
 import {EvoTabsService} from '../evo-tabs.service';
 import {filter, takeUntil} from 'rxjs/operators';
 import {EvoTabState} from '../evo-tab-state.collection';
-import {NavigationEnd, Router, RouterLink} from '@angular/router';
+import {IsActiveMatchOptions, NavigationEnd, Router, RouterLink} from '@angular/router';
 import {Subject} from 'rxjs';
 import {EvoTabsSizeService} from '../evo-tabs-size.service';
 import {EvoTabsSize} from '../enums/evo-tabs-size';
@@ -17,12 +17,27 @@ import {EvoUiClassDirective} from '../../../directives/evo-ui-class.directive';
 })
 export class EvoTabComponent implements OnInit, AfterViewInit, OnDestroy {
     @Input() name: string;
-    @Input() activeMatchOptions = true;
+
+    @Input()
+    set activeMatchOptions(activeMatchOptions: IsActiveMatchOptions | boolean) {
+        this._activeMatchOptions = activeMatchOptions;
+    }
+
+    get activeMatchOptions(): IsActiveMatchOptions {
+        if (typeof this._activeMatchOptions === 'boolean') {
+            return this._activeMatchOptions
+                ? {paths: 'exact', queryParams: 'exact', fragment: 'ignored', matrixParams: 'ignored'}
+                : {paths: 'subset', queryParams: 'subset', fragment: 'ignored', matrixParams: 'ignored'};
+        }
+
+        return this._activeMatchOptions;
+    }
 
     selected = false;
     size = this.sizeService.size;
 
     private _groupName: string;
+    private _activeMatchOptions: IsActiveMatchOptions | boolean = true;
     private readonly destroy$ = new Subject<void>();
 
     constructor(

--- a/projects/evo-ui-kit/src/lib/components/evo-tabs/evo-tabs.component.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tabs/evo-tabs.component.spec.ts
@@ -75,6 +75,7 @@ const routes: Routes = [
     {path: 'home', component: EvoStubContentComponent},
     {path: 'news', component: EvoStubContentComponent},
     {path: 'about', component: EvoStubContentComponent},
+    {path: 'esm/problems', component: EvoStubContentComponent},
 ];
 
 @Component({
@@ -84,6 +85,7 @@ const routes: Routes = [
             <a evoTab name="home" [routerLink]="'home'">home</a>
             <a #newsTab evoTab name="news" [routerLink]="'news'">news</a>
             <a evoTab name="about" [routerLink]="'about'">about</a>
+            <a evoTab name="problems" routerLink="/esm/problems" [activeMatchOptions]="activeMatchOptions">problems</a>
         </evo-tabs>
         <router-outlet />
     `,
@@ -91,6 +93,8 @@ const routes: Routes = [
     imports: [EvoTabsModule, RouterOutlet, RouterLink],
 })
 export class EvoTabsLinkWrapperComponent {
+    activeMatchOptions = true;
+
     @ViewChild('newsTab', {read: ElementRef}) newsTab: ElementRef;
     @ViewChild(EvoTabsComponent) tabs: EvoTabsComponent;
 }
@@ -403,6 +407,23 @@ describe('EvoTabsComponent', () => {
         tick();
         const isNewsRoute = router.url.indexOf('news') !== -1;
         expect(newsTabState.isActive && isNewsRoute).toBeTruthy();
+    }));
+
+    it('should activate tab with additional query params when exact matching is disabled', fakeAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [EvoTabsModule, EvoTabsLinkWrapperComponent, EvoStubContentComponent],
+            providers: [provideRouter(routes)],
+        });
+        const router = TestBed.inject(Router);
+
+        router.navigateByUrl('/esm/problems?presetId=423');
+        tick();
+        const fixture = TestBed.createComponent(EvoTabsLinkWrapperComponent);
+        fixture.componentInstance.activeMatchOptions = false;
+        fixture.detectChanges();
+
+        const problemsTab = fixture.componentInstance.tabs.tabComponentsList.find((tab) => tab.name === 'problems');
+        expect(problemsTab.selected).toBeTruthy();
     }));
 
     it(`should be ${EvoTabsSize.normal} size if size is default`, () => {

--- a/projects/evo-ui-kit/src/lib/components/evo-tabs/evo-tabs.component.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-tabs/evo-tabs.component.spec.ts
@@ -426,6 +426,22 @@ describe('EvoTabsComponent', () => {
         expect(problemsTab.selected).toBeTruthy();
     }));
 
+    it('should not activate tab with additional query params when exact matching is default', fakeAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [EvoTabsModule, EvoTabsLinkWrapperComponent, EvoStubContentComponent],
+            providers: [provideRouter(routes)],
+        });
+        const router = TestBed.inject(Router);
+
+        router.navigateByUrl('/esm/problems?presetId=423');
+        tick();
+        const fixture = TestBed.createComponent(EvoTabsLinkWrapperComponent);
+        fixture.detectChanges();
+
+        const problemsTab = fixture.componentInstance.tabs.tabComponentsList.find((tab) => tab.name === 'problems');
+        expect(problemsTab.selected).toBeFalsy();
+    }));
+
     it(`should be ${EvoTabsSize.normal} size if size is default`, () => {
         host = createHost(`
             <evo-tabs [name]="groupName">

--- a/src/stories/components/evo-tabs.stories.ts
+++ b/src/stories/components/evo-tabs.stories.ts
@@ -24,6 +24,9 @@ const routes: Routes = [
     {path: 'home', component: StubContentComponent, data: {content: 'Home'}},
     {path: 'news', component: StubContentComponent, data: {content: 'News'}},
     {path: 'about', component: StubContentComponent, data: {content: 'About'}},
+    {path: 'esm/home', component: StubContentComponent, data: {content: 'ESM home'}},
+    {path: 'esm/problems', component: StubContentComponent, data: {content: 'Problems'}},
+    {path: 'esm/tickets', component: StubContentComponent, data: {content: 'Tickets'}},
     {path: '**', redirectTo: 'news', pathMatch: 'full'},
 ];
 
@@ -250,6 +253,33 @@ export const LinkTabs = () => ({
 });
 
 LinkTabs.storyName = 'link tabs';
+
+export const LinkTabsWithNonExactMatch = () => ({
+    template: `
+            <evo-tabs name="non-exact-links">
+                <a
+                    *ngFor="let tab of linkTabsList"
+                    evoTab
+                    [name]="tab.label"
+                    [routerLink]="tab.link"
+                    [queryParams]="tab.queryParams"
+                    [activeMatchOptions]="false"
+                >
+                    {{ tab.label }}
+                </a>
+            </evo-tabs>
+            <router-outlet></router-outlet>
+        `,
+    props: {
+        linkTabsList: [
+            {label: 'Home', link: '/esm/home', queryParams: {source: 'storybook'}},
+            {label: 'Problems', link: '/esm/problems', queryParams: {presetId: 423}},
+            {label: 'Tickets', link: '/esm/tickets', queryParams: {filters: 'active'}},
+        ],
+    },
+});
+
+LinkTabsWithNonExactMatch.storyName = 'link tabs with non-exact match';
 
 export const SmallTabs = () => ({
     template: `


### PR DESCRIPTION
Add activeMatchOptions input to EvoTabComponent and use it for Router.isActive checks while keeping exact matching as the default.

Cover query-param matching in specs and add a Storybook scenario.