### PR TITLE
feat(styles)!: свести медиа-брейкпоинты к 4 тирам (768/1272/1528)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,10 +1,34 @@
 # Миграция
 
+- [Медиа-брейкпоинты сведены к 4 тирам (20.0.0)](#media-breakpoints-4-tiers)
 - [Подписи строк evo-table гейтятся по вьюпорту (20.0.0)](#evo-table-viewport-gate)
 - [Мобильная подпись строки evo-table (20.0.0)](#evo-table-mobile-label)
 - [Ячейка evo-table обновляется только по смене ссылок (20.0.0)](#evo-table-cell-reactivity)
 - [Рефакторинг evo-table (8.25+)](#evo-table-refactor)
 - [С версии 7.x до 8.0.0](#from-7x-to-800)
+
+## <a name="media-breakpoints-4-tiers"></a> Медиа-брейкпоинты сведены к 4 тирам (20.0.0)
+
+**BREAKING CHANGE.**
+Набор медиа-брейкпоинтов сокращён с 6 тиров до 4, а значения приведены к эталону evo-market.
+
+Было (6 тиров): `mobile 500 / tablet 768 / desktop-s 992 / desktop-m 1200 / desktop-l 1680 / desktop-xl 2500`.
+Стало (4 тира): `mobile 360 / tablet 768 / desktop-s 1280 / desktop-m 1536`.
+
+Изменения затрагивают оба публичных контракта пакета - SCSS (`@evotor-dev/ui-kit/styles/...`) и TS (`CSS_BREAKPOINTS`):
+
+- Удалены SCSS-миксины `media-desktop-l`, `media-desktop-xl` и переменные `$media-desktop-l`, `$media-desktop-xl`.
+- Удалены ключи `desktopL`, `desktopXL` из `CSS_BREAKPOINTS`.
+- Сдвинуты значения: `$media-mobile` 500→360, `$media-desktop-s` 992→1280, `$media-desktop-m` 1200→1536. `$media-tablet` не изменился (768).
+
+Внутри самого ui-kit `$media-mobile` раньше служил границей схлопывания форм (`evo-form`, `evo-note`).
+Теперь эти компоненты используют миксин `@include media-mobile` (граница `< 768`), а не сырой `$media-mobile`, - вёрстка форм на узких экранах схлопывается по единой мобильной границе.
+
+Что делать при миграции:
+
+- Если вы использовали миксины `media-desktop-l` / `media-desktop-xl` или ключи `CSS_BREAKPOINTS.desktopL` / `desktopXL` - перенесите логику на `media-desktop-m` (1536) или соберите собственный медиазапрос.
+- Если вы завязаны на конкретные px значений `desktop-s` / `desktop-m` / `mobile` - перепроверьте вёрстку: пороги сдвинулись (см. выше).
+- `tablet` (768) стабилен - код, завязанный только на него, менять не нужно.
 
 ## <a name="evo-table-viewport-gate"></a> Подписи строк evo-table гейтятся по вьюпорту (20.0.0)
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -10,23 +10,26 @@
 ## <a name="media-breakpoints-4-tiers"></a> Медиа-брейкпоинты сведены к 4 тирам (20.0.0)
 
 **BREAKING CHANGE.**
-Набор медиа-брейкпоинтов сокращён с 6 тиров до 4, а значения приведены к эталону evo-market.
+Набор медиа-брейкпоинтов сокращён с 6 тиров до 4, значения - по актуальной дизайн-сетке.
 
 Было (6 тиров): `mobile 500 / tablet 768 / desktop-s 992 / desktop-m 1200 / desktop-l 1680 / desktop-xl 2500`.
-Стало (4 тира): `mobile 360 / tablet 768 / desktop-s 1280 / desktop-m 1536`.
+Стало (4 тира): `mobile 0-767 / tablet 768-1271 / desktop-s 1272-1527 / desktop-m 1528+`.
 
 Изменения затрагивают оба публичных контракта пакета - SCSS (`@evotor-dev/ui-kit/styles/...`) и TS (`CSS_BREAKPOINTS`):
 
 - Удалены SCSS-миксины `media-desktop-l`, `media-desktop-xl` и переменные `$media-desktop-l`, `$media-desktop-xl`.
 - Удалены ключи `desktopL`, `desktopXL` из `CSS_BREAKPOINTS`.
-- Сдвинуты значения: `$media-mobile` 500→360, `$media-desktop-s` 992→1280, `$media-desktop-m` 1200→1536. `$media-tablet` не изменился (768).
+- Удалена переменная `$media-mobile`: в новой сетке у mobile нет нижнего порога, это всё, что уже `$media-tablet`. Используйте миксин `@include media-mobile`.
+- Сдвинуты значения: `$media-desktop-s` 992→1272, `$media-desktop-m` 1200→1528. `$media-tablet` не изменился (768). В `CSS_BREAKPOINTS` значения - нижние границы тиров, `mobile` теперь `0` (был 500).
+- Миксины переведены на range-синтаксис медиазапросов (`width >=` / `width <`). Пара `< 768` / `>= 768` разбивает ось ширин без дыр: раньше дробные ширины 767-768px (зум, масштаб экрана) не попадали ни в `max-width: 767px`, ни в `min-width: 768px`. Требуются браузеры с поддержкой range-синтаксиса (Chrome 104+, Firefox 102+, Safari 16.4+).
 
 Внутри самого ui-kit `$media-mobile` раньше служил границей схлопывания форм (`evo-form`, `evo-note`).
-Теперь эти компоненты используют миксин `@include media-mobile` (граница `< 768`), а не сырой `$media-mobile`, - вёрстка форм на узких экранах схлопывается по единой мобильной границе.
+Теперь эти компоненты используют миксин `@include media-mobile` (граница `< 768`) - вёрстка форм на узких экранах схлопывается по единой мобильной границе.
 
 Что делать при миграции:
 
-- Если вы использовали миксины `media-desktop-l` / `media-desktop-xl` или ключи `CSS_BREAKPOINTS.desktopL` / `desktopXL` - перенесите логику на `media-desktop-m` (1536) или соберите собственный медиазапрос.
+- Если вы использовали миксины `media-desktop-l` / `media-desktop-xl` или ключи `CSS_BREAKPOINTS.desktopL` / `desktopXL` - перенесите логику на `media-desktop-m` (1528) или соберите собственный медиазапрос.
+- Если вы использовали `$media-mobile` в своих медиазапросах - перейдите на `@include media-mobile` (или `width < $media-tablet`).
 - Если вы завязаны на конкретные px значений `desktop-s` / `desktop-m` / `mobile` - перепроверьте вёрстку: пороги сдвинулись (см. выше).
 - `tablet` (768) стабилен - код, завязанный только на него, менять не нужно.
 

--- a/projects/evo-ui-kit/src/lib/common/constants/css-breakpoints.ts
+++ b/projects/evo-ui-kit/src/lib/common/constants/css-breakpoints.ts
@@ -1,8 +1,6 @@
 export const CSS_BREAKPOINTS = {
-    mobile: 500,
+    mobile: 360,
     tablet: 768,
-    desktopS: 992,
-    desktopM: 1200,
-    desktopL: 1680,
-    desktopXL: 2500,
+    desktopS: 1280,
+    desktopM: 1536,
 };

--- a/projects/evo-ui-kit/src/lib/common/constants/css-breakpoints.ts
+++ b/projects/evo-ui-kit/src/lib/common/constants/css-breakpoints.ts
@@ -1,6 +1,10 @@
+/**
+ * Нижние границы брейкпоинт-тиров (px).
+ * Тиры: mobile 0-767 / tablet 768-1271 / desktopS 1272-1527 / desktopM 1528+.
+ */
 export const CSS_BREAKPOINTS = {
-    mobile: 360,
+    mobile: 0,
     tablet: 768,
-    desktopS: 1280,
-    desktopM: 1536,
+    desktopS: 1272,
+    desktopM: 1528,
 };

--- a/projects/evo-ui-kit/src/lib/components/evo-note/evo-note.component.scss
+++ b/projects/evo-ui-kit/src/lib/components/evo-note/evo-note.component.scss
@@ -40,13 +40,13 @@ $icon-size: 48px;
     }
 
     &__icon {
-        display: none;
+        display: block;
         flex: 0 0 var(--evo-note-icon-size);
         align-self: start;
         height: var(--evo-note-icon-size);
 
-        @media (min-width: $media-mobile) {
-            display: block;
+        @include media-mobile {
+            display: none;
         }
     }
 

--- a/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper.component.scss
+++ b/projects/evo-ui-kit/src/lib/components/evo-stepper/evo-stepper.component.scss
@@ -138,7 +138,8 @@ $root: '.evo-stepper';
     }
 }
 
-@media (max-width: 768px) {
+// Ровно 768px - уже tablet: раньше захардкоженный max-width: 768px пересекался с media-tablet.
+@include media-mobile {
     #{$root} {
         &__current-step-name {
             display: block;

--- a/projects/evo-ui-kit/src/lib/styles/components/evo-form.scss
+++ b/projects/evo-ui-kit/src/lib/styles/components/evo-form.scss
@@ -24,7 +24,7 @@ $evo-form-min-field-width: 100px;
 }
 
 .evo-form-col {
-    @media (max-width: $media-mobile) {
+    @include media-mobile {
         &:not(&_multi) {
             flex: 0 1 auto;
         }
@@ -71,7 +71,7 @@ $evo-form-min-field-width: 100px;
             margin: ($evo-form-gap-ver) ($evo-form-gap-hor) 0 0;
         }
 
-        @media (max-width: $media-mobile) {
+        @include media-mobile {
             flex-flow: column nowrap;
         }
     }
@@ -139,14 +139,14 @@ $evo-form-min-field-width: 100px;
     display: flex;
     flex-flow: row wrap;
 
-    @media (max-width: $media-mobile) {
+    @include media-mobile {
         flex-flow: column nowrap;
     }
 
     .evo-form-col:not(.evo-form-col_multi) {
         margin: ($evo-form-gap-ver) ($evo-form-gap-hor) 0 0;
 
-        @media (max-width: $media-mobile) {
+        @include media-mobile {
             margin: ($evo-form-gap-ver) 0 0 0;
         }
     }
@@ -180,7 +180,7 @@ $evo-form-min-field-width: 100px;
     .evo-form-row {
         margin: (-$evo-form-gap-ver) (-$evo-form-gap-hor) 0 0;
 
-        @media (max-width: $media-mobile) {
+        @include media-mobile {
             margin: (-$evo-form-gap-ver) 0 0 0;
         }
     }
@@ -216,7 +216,7 @@ $evo-form-min-field-width: 100px;
                 margin-left: auto;
             }
 
-            @media (max-width: $media-mobile) {
+            @include media-mobile {
                 margin: $evo-form-gap-ver 0 0 0;
             }
         }
@@ -258,7 +258,7 @@ $evo-form-min-field-width: 100px;
             margin-left: auto;
         }
 
-        @media (max-width: $media-mobile) {
+        @include media-mobile {
             margin: $evo-form-gap-ver 0 0 0;
         }
     }

--- a/projects/evo-ui-kit/src/lib/styles/globals.scss
+++ b/projects/evo-ui-kit/src/lib/styles/globals.scss
@@ -1,4 +1,5 @@
 @import 'variables';
+@import 'mixins/media-mixins';
 
 * {
     box-sizing: border-box;
@@ -47,13 +48,13 @@ a {
 }
 
 .mobile-show {
-    @media (min-width: #{$media-tablet}) {
+    @include media-tablet {
         display: none !important;
     }
 }
 
 .mobile-hide {
-    @media (max-width: #{$media-tablet - 1px}) {
+    @include media-mobile {
         display: none !important;
     }
 }

--- a/projects/evo-ui-kit/src/lib/styles/mixins/_media-mixins.scss
+++ b/projects/evo-ui-kit/src/lib/styles/mixins/_media-mixins.scss
@@ -1,26 +1,31 @@
 @import '../variables';
 
+// Тиры: mobile 0-767 / tablet 768-1271 / desktop-s 1272-1527 / desktop-m 1528+.
+// Range-синтаксис (`width >=` / `width <`) вместо min-/max-width: пара `< 768` и `>= 768`
+// разбивает ось ширин без дыр - у пары max-width: 767px / min-width: 768px дробные
+// ширины 767-768px (зум, масштаб экрана) не попадали ни в один запрос.
+
 @mixin media-mobile {
-    @media (max-width: #{$media-tablet - 1}) {
+    @media (width < $media-tablet) {
         @content;
     }
 }
 
 /* media mixins - mobile first*/
 @mixin media-tablet {
-    @media (min-width: #{$media-tablet}) {
+    @media (width >= $media-tablet) {
         @content;
     }
 }
 
 @mixin media-desktop-s {
-    @media (min-width: #{$media-desktop-s}) {
+    @media (width >= $media-desktop-s) {
         @content;
     }
 }
 
 @mixin media-desktop-m {
-    @media (min-width: #{$media-desktop-m}) {
+    @media (width >= $media-desktop-m) {
         @content;
     }
 }

--- a/projects/evo-ui-kit/src/lib/styles/mixins/_media-mixins.scss
+++ b/projects/evo-ui-kit/src/lib/styles/mixins/_media-mixins.scss
@@ -24,15 +24,3 @@
         @content;
     }
 }
-
-@mixin media-desktop-l {
-    @media (min-width: #{$media-desktop-l}) {
-        @content;
-    }
-}
-
-@mixin media-desktop-xl {
-    @media (min-width: #{$media-desktop-xl}) {
-        @content;
-    }
-}

--- a/projects/evo-ui-kit/src/lib/styles/variables.scss
+++ b/projects/evo-ui-kit/src/lib/styles/variables.scss
@@ -85,11 +85,12 @@ $font-size: 14px;
 $line-height: 22px;
 
 // media variables
+// Нижние границы тиров: mobile 0-767 / tablet 768-1271 / desktop-s 1272-1527 / desktop-m 1528+.
+// У mobile нет своей переменной - это всё, что уже $media-tablet (см. media-mixins).
 // ------------------------------------------------------------
-$media-mobile: 360px;
 $media-tablet: 768px;
-$media-desktop-s: 1280px;
-$media-desktop-m: 1536px;
+$media-desktop-s: 1272px;
+$media-desktop-m: 1528px;
 
 // layout sizes
 // ------------------------------------------------------------

--- a/projects/evo-ui-kit/src/lib/styles/variables.scss
+++ b/projects/evo-ui-kit/src/lib/styles/variables.scss
@@ -86,12 +86,10 @@ $line-height: 22px;
 
 // media variables
 // ------------------------------------------------------------
-$media-mobile: 500px;
+$media-mobile: 360px;
 $media-tablet: 768px;
-$media-desktop-s: 992px;
-$media-desktop-m: 1200px;
-$media-desktop-l: 1680px;
-$media-desktop-xl: 2500px;
+$media-desktop-s: 1280px;
+$media-desktop-m: 1536px;
 
 // layout sizes
 // ------------------------------------------------------------


### PR DESCRIPTION
## Что и зачем

Сведение медиа-брейкпоинтов к 4 тирам по утверждённой дизайн-сетке: было 6 тиров, стало 4.

**Было:** `mobile 500 / tablet 768 / desktop-s 992 / desktop-m 1200 / desktop-l 1680 / desktop-xl 2500`
**Стало:** `mobile 0-767 / tablet 768-1271 / desktop-s 1272-1527 / desktop-m 1528+`

## Изменения (публичные контракты - SCSS + TS)

- `styles/variables.scss` - пороги `$media-desktop-s: 1272px`, `$media-desktop-m: 1528px`; удалены `$media-desktop-l/xl` и `$media-mobile` (в новой сетке у mobile нет нижнего порога - это всё, что `< $media-tablet`).
- `styles/mixins/_media-mixins.scss` - удалены миксины `media-desktop-l/xl`; оставшиеся переведены на range-синтаксис (`width >=` / `width <`). Пара `< 768` / `>= 768` закрывает дыру дробных ширин 767-768px, которая была у `max-width: 767px` / `min-width: 768px`. В скомпилированном CSS компонентов Angular транспилирует это в совместимые формы (`not (min-width: ...)` и т.п.); range-синтаксис в сыром виде уезжает только потребителям SCSS-исходников (нужен Dart Sass 1.56+).
- `common/constants/css-breakpoints.ts` - `CSS_BREAKPOINTS` = 4 ключа, значения = нижние границы тиров (`mobile: 0`).
- `evo-form.scss` (×7), `evo-note.component.scss` - переведены с сырого `$media-mobile` на миксин `@include media-mobile` (граница `< 768`).
- `evo-stepper.component.scss` - захардкоженный `@media (max-width: 768px)` пересекался с `media-tablet` на ровно 768px; заменён на `@include media-mobile`.
- `styles/globals.scss` - утилиты `.mobile-show` / `.mobile-hide` переведены с сырых `min/max-width` на миксины.
- `MIGRATION.md` - запись про breaking change.

## ⚠️ BREAKING CHANGE

Удаление тиров/переменных и сдвиг значений затрагивают оба публичных контракта (`@evotor-dev/ui-kit/styles/...` и `CSS_BREAKPOINTS`). Внутри ui-kit `desktop-l/xl` не использовались; grid-container система (мёртвая, 0 потребителей) не трогалась.

## Проверка

- `npm run build` (gulp / ng-packagr) - зелёная, в скомпилированном CSS ожидаемые запросы: `not (min-width:768px)` / `min-width:768px` / `min-width:1272px` / `min-width:1528px`.
- `npm run test:ci` - 545 SUCCESS.
- `npm run lint` - чисто.
- `grep '$media-mobile|desktop-l|desktop-xl'` по `projects` - чисто.

## Дальше (отдельные PR/ветки)

Часть многоэтапной синхронизации: далее актуализация **evo-bonus-lk** (MR frontend-integration!79) под новую beta и **VRT-вьюпорты** (4 вьюпорта) + перегенерация бейзлайнов.
