### PR TITLE
fix(evo-datepicker): render the initial value inside OnPush subtrees

### DIFF
--- a/projects/evo-ui-kit/src/lib/components/evo-datepicker/evo-datepicker.component.html
+++ b/projects/evo-ui-kit/src/lib/components/evo-datepicker/evo-datepicker.component.html
@@ -1,6 +1,5 @@
 <div #flatpickr class="evo-datepicker" [evoUiClass]="totalClasses" (click)="onDatepickerClick($event)">
     <input
-        #input
         type="text"
         data-input
         class="evo-datepicker__input"
@@ -11,8 +10,8 @@
         (complete)="handleMaskComplete($event)"
     />
 
-    @if (isRange() && input.value) {
-        <span class="evo-datepicker__value">{{ input.value }}</span>
+    @if (isRange() && displayValue()) {
+        <span class="evo-datepicker__value">{{ displayValue() }}</span>
     }
 
     @if (shouldShowEmptyText()) {

--- a/projects/evo-ui-kit/src/lib/components/evo-datepicker/evo-datepicker.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-datepicker/evo-datepicker.component.ts
@@ -187,7 +187,8 @@ export class EvoDatepickerComponent
     }
 
     ngOnChanges(changes: SimpleChanges) {
-        if (changes.hasOwnProperty('setDate') && changes['setDate'].currentValue) {
+        // До ngAfterViewInit инстанса ещё нет, начальное значение setDate применяется там же.
+        if (this.flatpickr && changes['setDate']?.currentValue) {
             this.setDateFromInput(changes['setDate'].currentValue, false);
         }
     }
@@ -197,7 +198,7 @@ export class EvoDatepickerComponent
     }
 
     ngOnDestroy() {
-        this.flatpickr.destroy();
+        this.flatpickr?.destroy();
         this.flatpickr = null;
     }
 

--- a/projects/evo-ui-kit/src/lib/components/evo-datepicker/evo-datepicker.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-datepicker/evo-datepicker.component.ts
@@ -159,13 +159,13 @@ export class EvoDatepickerComponent
 
     handleMaskComplete(value) {
         if (this.maskedInput) {
-            const date = this.flatpickrElement.nativeElement._flatpickr.parseDate(value, this.config.dateFormat);
+            const date = this.flatpickr.parseDate(value, this.config.dateFormat);
             this.setDateFromInput(date);
         }
     }
 
     setDateFromInput(date: SelectedDates, triggerChange = true) {
-        this.flatpickrElement.nativeElement._flatpickr.setDate(date, triggerChange);
+        this.flatpickr.setDate(date, triggerChange);
     }
 
     ngAfterViewInit() {
@@ -197,8 +197,8 @@ export class EvoDatepickerComponent
     }
 
     ngOnDestroy() {
+        this.flatpickr.destroy();
         this.flatpickr = null;
-        this.flatpickrElement.nativeElement._flatpickr.destroy();
     }
 
     initMask() {

--- a/projects/evo-ui-kit/src/lib/components/evo-datepicker/evo-datepicker.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-datepicker/evo-datepicker.component.ts
@@ -107,9 +107,8 @@ export class EvoDatepickerComponent
     private pendingValue: SelectedDates | null = null;
 
     /**
-     * Текст, показанный в поле.
-     * Хранится в сигнале, а не читается из DOM: flatpickr пишет в инпут уже после проверки вью,
-     * поэтому прочитанное шаблоном значение не попадает в первый рендер.
+     * Отображаемый текст поля: flatpickr пишет в инпут уже после проверки вью, поэтому шаблон
+     * не может читать DOM. Состояние выбора при этом остаётся во flatpickr.selectedDates.
      */
     protected readonly displayValue = signal('');
 
@@ -193,12 +192,12 @@ export class EvoDatepickerComponent
         // колбэков, поэтому свой onChange потребителя вытеснил бы наш целиком. У готового инстанса
         // onChange - это список хуков, и добавление в него ничего не затирает.
         this.flatpickr.config.onChange.push(() => this.syncDisplayValue());
+        this.syncDisplayValue();
 
         if (this.setDate) {
             this.setDateFromInput(this.setDate, false);
         }
         this.customizePicker();
-        this.syncDisplayValue();
     }
 
     ngOnChanges(changes: SimpleChanges) {
@@ -247,7 +246,7 @@ export class EvoDatepickerComponent
     }
 
     isValueExist(): boolean {
-        return this.displayValue() !== '';
+        return !!this.displayValue();
     }
 
     isRange(): boolean {
@@ -601,7 +600,7 @@ export class EvoDatepickerComponent
     }
 
     private syncDisplayValue(): void {
-        this.displayValue.set(this.flatpickr?.input.value ?? '');
+        this.displayValue.set(this.flatpickr.input.value);
     }
 
     private updatePickerIfNeed(value: SelectedDates): void {

--- a/projects/evo-ui-kit/src/lib/components/evo-datepicker/evo-datepicker.component.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-datepicker/evo-datepicker.component.ts
@@ -11,6 +11,7 @@ import {
     OnDestroy,
     OnInit,
     Output,
+    signal,
     SimpleChanges,
     ViewChild,
     ViewEncapsulation,
@@ -105,6 +106,13 @@ export class EvoDatepickerComponent
     private flatpickr: any;
     private pendingValue: SelectedDates | null = null;
 
+    /**
+     * Текст, показанный в поле.
+     * Хранится в сигнале, а не читается из DOM: flatpickr пишет в инпут уже после проверки вью,
+     * поэтому прочитанное шаблоном значение не попадает в первый рендер.
+     */
+    protected readonly displayValue = signal('');
+
     constructor(
         private readonly zone: NgZone,
         private readonly elementRef: ElementRef,
@@ -166,6 +174,7 @@ export class EvoDatepickerComponent
 
     setDateFromInput(date: SelectedDates, triggerChange = true) {
         this.flatpickr.setDate(date, triggerChange);
+        this.syncDisplayValue();
     }
 
     ngAfterViewInit() {
@@ -180,10 +189,16 @@ export class EvoDatepickerComponent
             this.flatpickr = flatpickr(this.flatpickrElement.nativeElement, config);
         });
 
+        // Синхронизацию нельзя отдать в getConfig(): там конфигурация потребителя ложится поверх наших
+        // колбэков, поэтому свой onChange потребителя вытеснил бы наш целиком. У готового инстанса
+        // onChange - это список хуков, и добавление в него ничего не затирает.
+        this.flatpickr.config.onChange.push(() => this.syncDisplayValue());
+
         if (this.setDate) {
             this.setDateFromInput(this.setDate, false);
         }
         this.customizePicker();
+        this.syncDisplayValue();
     }
 
     ngOnChanges(changes: SimpleChanges) {
@@ -232,16 +247,7 @@ export class EvoDatepickerComponent
     }
 
     isValueExist(): boolean {
-        if (!this.flatpickr) {
-            if (this.pendingValue?.length) {
-                return true;
-            }
-            const defaultDate = this.config.defaultDate;
-
-            return Array.isArray(defaultDate) ? (this.config.defaultDate as Date[]).length > 0 : !!defaultDate;
-        } else {
-            return this.flatpickr.selectedDates.length > 0;
-        }
+        return this.displayValue() !== '';
     }
 
     isRange(): boolean {
@@ -592,6 +598,10 @@ export class EvoDatepickerComponent
         if (this.isRange() && this.flatpickr.selectedDates.length !== 2) {
             this.setEmptyFieldState(true);
         }
+    }
+
+    private syncDisplayValue(): void {
+        this.displayValue.set(this.flatpickr?.input.value ?? '');
     }
 
     private updatePickerIfNeed(value: SelectedDates): void {

--- a/projects/evo-ui-kit/src/lib/components/evo-datepicker/evo-datepicker.onpush.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-datepicker/evo-datepicker.onpush.spec.ts
@@ -2,8 +2,6 @@ import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, Input} fr
 import {ComponentFixture, fakeAsync, TestBed, tick, waitForAsync} from '@angular/core/testing';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
 import {Russian} from 'flatpickr/dist/l10n/ru';
-import {of} from 'rxjs';
-import {delay} from 'rxjs/operators';
 import {EvoDatepickerComponent, FlatpickrOptions} from './evo-datepicker.component';
 
 const RANGE_VALUE = [new Date(2018, 3, 5), new Date(2018, 3, 12)];
@@ -14,14 +12,21 @@ const singleConfig: FlatpickrOptions = {locale: Russian, dateFormat: 'd.m.Y'};
 const maskedConfig: FlatpickrOptions = {locale: Russian, dateFormat: 'd.m.Y', allowInput: true};
 
 @Component({
-    selector: 'evo-onpush-range-host',
-    template: `<evo-datepicker [config]="config" theme="range" [formControl]="control" />`,
+    selector: 'evo-onpush-host',
+    template: `<evo-datepicker
+        [config]="config"
+        [theme]="theme"
+        [maskedInput]="maskedInput"
+        [formControl]="control"
+    />`,
     standalone: true,
     imports: [ReactiveFormsModule, EvoDatepickerComponent],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-class OnPushRangeHostComponent {
-    config = rangeConfig;
+class OnPushHostComponent {
+    @Input() config: FlatpickrOptions = rangeConfig;
+    @Input() theme?: string = 'range';
+    @Input() maskedInput = false;
     @Input() control = new FormControl<Date[]>(RANGE_VALUE);
 }
 
@@ -34,18 +39,6 @@ class OnPushRangeHostComponent {
 class DefaultRangeHostComponent {
     config = rangeConfig;
     control = new FormControl<Date[]>(RANGE_VALUE);
-}
-
-@Component({
-    selector: 'evo-onpush-single-host',
-    template: `<evo-datepicker [config]="config" [formControl]="control" />`,
-    standalone: true,
-    imports: [ReactiveFormsModule, EvoDatepickerComponent],
-    changeDetection: ChangeDetectionStrategy.OnPush,
-})
-class OnPushSingleHostComponent {
-    config = singleConfig;
-    @Input() control = new FormControl<Date[]>(SINGLE_VALUE);
 }
 
 @Component({
@@ -69,53 +62,26 @@ class OnPushAsyncHostComponent {
     // Эмуляция боевого пути: ответ HTTP приходит макрозадачей, поддерево создаётся внутри того же
     // прохода CD - следующего тика, в котором мог бы сработать markForCheck из ngAfterViewInit, нет.
     load(): void {
-        of(RANGE_VALUE)
-            .pipe(delay(0))
-            .subscribe((value) => {
-                this.control.setValue(value);
-                this.loaded = true;
-                this.cdr.markForCheck();
-            });
+        setTimeout(() => {
+            this.control.setValue(RANGE_VALUE);
+            this.loaded = true;
+            this.cdr.markForCheck();
+        });
     }
-}
-
-@Component({
-    selector: 'evo-onpush-branch',
-    template: `<evo-datepicker [config]="config" [theme]="theme" [formControl]="control" />`,
-    standalone: true,
-    imports: [ReactiveFormsModule, EvoDatepickerComponent],
-    changeDetection: ChangeDetectionStrategy.OnPush,
-})
-class OnPushBranchComponent {
-    @Input() config: FlatpickrOptions;
-    @Input() theme: string;
-    @Input() control: FormControl<Date[]>;
 }
 
 // Боевая расстановка потребителя: обычный корень, между ним и датапикером - OnPush-компонент.
 // Проход CD от корня в такую ветку не заходит, пока её кто-нибудь не пометит грязной.
 @Component({
     selector: 'evo-default-root-host',
-    template: `<evo-onpush-branch [config]="config" [theme]="theme" [control]="control" />`,
+    template: `<evo-onpush-host [config]="config" [theme]="theme" [control]="control" />`,
     standalone: true,
-    imports: [OnPushBranchComponent],
+    imports: [OnPushHostComponent],
 })
 class DefaultRootHostComponent {
     @Input() config = rangeConfig;
     @Input() theme = 'range';
     @Input() control = new FormControl<Date[]>(null);
-}
-
-@Component({
-    selector: 'evo-onpush-masked-host',
-    template: `<evo-datepicker [config]="config" [maskedInput]="true" [formControl]="control" />`,
-    standalone: true,
-    imports: [ReactiveFormsModule, EvoDatepickerComponent],
-    changeDetection: ChangeDetectionStrategy.OnPush,
-})
-class OnPushMaskedHostComponent {
-    config = maskedConfig;
-    control = new FormControl<Date[]>(SINGLE_VALUE);
 }
 
 @Component({
@@ -137,35 +103,45 @@ const emptyText = (fixture: ComponentFixture<unknown>): HTMLElement =>
 const pickerInput = (fixture: ComponentFixture<unknown>): HTMLInputElement =>
     fixture.nativeElement.querySelector('.evo-datepicker__input');
 
-describe('EvoDatepickerComponent: первый рендер под OnPush-хостом', () => {
+const expectRenderedValue = (fixture: ComponentFixture<unknown>): void => {
+    const span = valueSpan(fixture);
+
+    expect(span).not.toBeNull();
+    expect(span.textContent.trim()).toBe(pickerInput(fixture).value);
+};
+
+const createOnPushHost = (inputs: Partial<OnPushHostComponent> = {}): ComponentFixture<OnPushHostComponent> => {
+    const fixture = TestBed.createComponent(OnPushHostComponent);
+    Object.entries(inputs).forEach(([name, value]) => fixture.componentRef.setInput(name, value));
+
+    return fixture;
+};
+
+describe('EvoDatepickerComponent: first render under an OnPush host', () => {
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
             imports: [
-                OnPushRangeHostComponent,
+                OnPushHostComponent,
                 DefaultRangeHostComponent,
-                OnPushSingleHostComponent,
                 OnPushAsyncHostComponent,
                 OnPushSetDateHostComponent,
-                OnPushMaskedHostComponent,
                 DefaultRootHostComponent,
             ],
         }).compileComponents();
     }));
 
     // Значение из форм-контрола должно быть видно сразу, без единого события в поддереве.
-    it('range: показывает значение форм-контрола после первого detectChanges', () => {
-        const fixture = TestBed.createComponent(OnPushRangeHostComponent);
+    it('should render the form control value on the first change detection run', () => {
+        const fixture = createOnPushHost();
 
         fixture.detectChanges();
 
-        const span = valueSpan(fixture);
-        expect(span).not.toBeNull();
-        expect(span.textContent.trim()).toBe(pickerInput(fixture).value);
-        expect(span.textContent).toContain('05.04.2018');
+        expectRenderedValue(fixture);
+        expect(valueSpan(fixture).textContent).toContain('05.04.2018');
         expect(emptyText(fixture)).toBeNull();
     });
 
-    it('range: значение приходит асинхронно, поддерево создаётся внутри прохода CD', fakeAsync(() => {
+    it('should render a value that arrives while the subtree is being created', fakeAsync(() => {
         const fixture = TestBed.createComponent(OnPushAsyncHostComponent);
         fixture.detectChanges();
 
@@ -173,21 +149,23 @@ describe('EvoDatepickerComponent: первый рендер под OnPush-хос
         tick();
         fixture.detectChanges();
 
-        const span = valueSpan(fixture);
-        expect(span).not.toBeNull();
-        expect(span.textContent.trim()).toBe(pickerInput(fixture).value);
+        expectRenderedValue(fixture);
     }));
 
     // Под Default-хостом тот же дефект виден как NG0100: @if переключается уже после проверки вью.
-    it('range: под обычным хостом первый detectChanges не бросает NG0100', () => {
+    it('should not throw NG0100 under a default change detection host', () => {
         const fixture = TestBed.createComponent(DefaultRangeHostComponent);
 
         expect(() => fixture.detectChanges()).not.toThrow();
         expect(valueSpan(fixture)).not.toBeNull();
     });
 
-    it('single: поле не скрыто и заглушка "Дата" не показана', () => {
-        const fixture = TestBed.createComponent(OnPushSingleHostComponent);
+    it('should keep the input visible and the placeholder hidden in single mode', () => {
+        const fixture = createOnPushHost({
+            config: singleConfig,
+            theme: undefined,
+            control: new FormControl<Date[]>(SINGLE_VALUE),
+        });
 
         fixture.detectChanges();
 
@@ -197,9 +175,8 @@ describe('EvoDatepickerComponent: первый рендер под OnPush-хос
         expect(emptyText(fixture)).toBeNull();
     });
 
-    it('range: пустой контрол показывает "За период" и не рисует значение', () => {
-        const fixture = TestBed.createComponent(OnPushRangeHostComponent);
-        fixture.componentRef.setInput('control', new FormControl<Date[]>(null));
+    it('should show the range placeholder and no value for an empty control', () => {
+        const fixture = createOnPushHost({control: new FormControl<Date[]>(null)});
 
         fixture.detectChanges();
 
@@ -207,9 +184,12 @@ describe('EvoDatepickerComponent: первый рендер под OnPush-хос
         expect(emptyText(fixture).textContent.trim()).toBe('За период');
     });
 
-    it('single: пустой контрол показывает "Дата" и скрывает поле', () => {
-        const fixture = TestBed.createComponent(OnPushSingleHostComponent);
-        fixture.componentRef.setInput('control', new FormControl<Date[]>(null));
+    it('should show the single placeholder and hide the input for an empty control', () => {
+        const fixture = createOnPushHost({
+            config: singleConfig,
+            theme: undefined,
+            control: new FormControl<Date[]>(null),
+        });
 
         fixture.detectChanges();
 
@@ -217,7 +197,7 @@ describe('EvoDatepickerComponent: первый рендер под OnPush-хос
         expect(pickerInput(fixture).classList.contains('evo-datepicker__input_hidden')).toBeTrue();
     });
 
-    it('[setDate]: значение задано на момент создания', () => {
+    it('should apply a [setDate] value bound at creation time', () => {
         const fixture = TestBed.createComponent(OnPushSetDateHostComponent);
         fixture.componentRef.setInput('dates', RANGE_VALUE);
 
@@ -226,7 +206,7 @@ describe('EvoDatepickerComponent: первый рендер под OnPush-хос
         expect(valueSpan(fixture)).not.toBeNull();
     });
 
-    it('[setDate]: значение меняется после инициализации', () => {
+    it('should apply a [setDate] value changed after initialization', () => {
         const fixture = TestBed.createComponent(OnPushSetDateHostComponent);
         fixture.detectChanges();
 
@@ -238,9 +218,9 @@ describe('EvoDatepickerComponent: первый рендер под OnPush-хос
         expect(emptyText(fixture)).toBeNull();
     });
 
-    // Программная запись значения в контрол не помечает OnPush-ветку грязной,
-    // поэтому пометить её должен сам компонент - иначе заглушка остаётся поверх заполненного поля.
-    it('range: setValue из внешнего источника обновляет значение сквозь OnPush-ветку', () => {
+    // Программная запись значения в контрол не помечает OnPush-ветку грязной - её метит
+    // прочитанный шаблоном сигнал displayValue, иначе заглушка остаётся поверх заполненного поля.
+    it('should render a value set on the control from outside through an OnPush branch', () => {
         const fixture = TestBed.createComponent(DefaultRootHostComponent);
         const control = new FormControl<Date[]>(null);
         fixture.componentRef.setInput('control', control);
@@ -250,13 +230,11 @@ describe('EvoDatepickerComponent: первый рендер под OnPush-хос
         control.setValue(RANGE_VALUE);
         fixture.detectChanges();
 
-        const span = valueSpan(fixture);
-        expect(span).not.toBeNull();
-        expect(span.textContent.trim()).toBe(pickerInput(fixture).value);
+        expectRenderedValue(fixture);
         expect(emptyText(fixture)).toBeNull();
     });
 
-    it('single: setValue из внешнего источника снимает заглушку "Дата" сквозь OnPush-ветку', () => {
+    it('should hide the single placeholder when the control is set from outside through an OnPush branch', () => {
         const fixture = TestBed.createComponent(DefaultRootHostComponent);
         const control = new FormControl<Date[]>(null);
         fixture.componentRef.setInput('config', singleConfig);
@@ -272,24 +250,33 @@ describe('EvoDatepickerComponent: первый рендер под OnPush-хос
         expect(pickerInput(fixture).classList.contains('evo-datepicker__input_hidden')).toBeFalse();
     });
 
-    it('маска ввода не искажает начальное значение', () => {
-        const fixture = TestBed.createComponent(OnPushMaskedHostComponent);
+    it('should not distort the initial value with the input mask', () => {
+        const fixture = createOnPushHost({
+            config: maskedConfig,
+            theme: undefined,
+            maskedInput: true,
+            control: new FormControl<Date[]>(SINGLE_VALUE),
+        });
 
         fixture.detectChanges();
 
         expect(pickerInput(fixture).value).toBe('05.04.2018');
     });
 
-    it('инпут остаётся readonly, когда config.allowInput не задан', () => {
-        const fixture = TestBed.createComponent(OnPushSingleHostComponent);
+    it('should keep the input readonly when config.allowInput is not set', () => {
+        const fixture = createOnPushHost({
+            config: singleConfig,
+            theme: undefined,
+            control: new FormControl<Date[]>(SINGLE_VALUE),
+        });
 
         fixture.detectChanges();
 
         expect(pickerInput(fixture).readOnly).toBeTrue();
     });
 
-    it('range: значение не пропадает после открытия и закрытия пикера', () => {
-        const fixture = TestBed.createComponent(OnPushRangeHostComponent);
+    it('should keep the value after opening and closing the picker', () => {
+        const fixture = createOnPushHost();
         fixture.detectChanges();
         const root: HTMLElement = fixture.nativeElement.querySelector('.evo-datepicker');
 
@@ -300,8 +287,6 @@ describe('EvoDatepickerComponent: первый рендер под OnPush-хос
         document.body.dispatchEvent(new MouseEvent('mousedown', {button: 0, bubbles: true}));
         fixture.detectChanges();
 
-        const span = valueSpan(fixture);
-        expect(span).not.toBeNull();
-        expect(span.textContent.trim()).toBe(pickerInput(fixture).value);
+        expectRenderedValue(fixture);
     });
 });

--- a/projects/evo-ui-kit/src/lib/components/evo-datepicker/evo-datepicker.onpush.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-datepicker/evo-datepicker.onpush.spec.ts
@@ -290,3 +290,18 @@ describe('EvoDatepickerComponent: first render under an OnPush host', () => {
         expectRenderedValue(fixture);
     });
 });
+
+describe('EvoDatepickerComponent: lifecycle before the calendar exists', () => {
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({imports: [EvoDatepickerComponent]}).compileComponents();
+    }));
+
+    // Компонент, выброшенный до первой проверки вью, не доходит до ngAfterViewInit,
+    // поэтому инстанса flatpickr к моменту ngOnDestroy ещё нет.
+    it('should not throw when destroyed before the calendar is created', () => {
+        const fixture = TestBed.createComponent(EvoDatepickerComponent);
+        fixture.componentInstance.config = singleConfig;
+
+        expect(() => fixture.componentInstance.ngOnDestroy()).not.toThrow();
+    });
+});

--- a/projects/evo-ui-kit/src/lib/components/evo-datepicker/evo-datepicker.onpush.spec.ts
+++ b/projects/evo-ui-kit/src/lib/components/evo-datepicker/evo-datepicker.onpush.spec.ts
@@ -1,0 +1,307 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, Input} from '@angular/core';
+import {ComponentFixture, fakeAsync, TestBed, tick, waitForAsync} from '@angular/core/testing';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {Russian} from 'flatpickr/dist/l10n/ru';
+import {of} from 'rxjs';
+import {delay} from 'rxjs/operators';
+import {EvoDatepickerComponent, FlatpickrOptions} from './evo-datepicker.component';
+
+const RANGE_VALUE = [new Date(2018, 3, 5), new Date(2018, 3, 12)];
+const SINGLE_VALUE = [new Date(2018, 3, 5)];
+
+const rangeConfig: FlatpickrOptions = {locale: Russian, dateFormat: 'd.m.Y', mode: 'range'};
+const singleConfig: FlatpickrOptions = {locale: Russian, dateFormat: 'd.m.Y'};
+const maskedConfig: FlatpickrOptions = {locale: Russian, dateFormat: 'd.m.Y', allowInput: true};
+
+@Component({
+    selector: 'evo-onpush-range-host',
+    template: `<evo-datepicker [config]="config" theme="range" [formControl]="control" />`,
+    standalone: true,
+    imports: [ReactiveFormsModule, EvoDatepickerComponent],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class OnPushRangeHostComponent {
+    config = rangeConfig;
+    @Input() control = new FormControl<Date[]>(RANGE_VALUE);
+}
+
+@Component({
+    selector: 'evo-default-range-host',
+    template: `<evo-datepicker [config]="config" theme="range" [formControl]="control" />`,
+    standalone: true,
+    imports: [ReactiveFormsModule, EvoDatepickerComponent],
+})
+class DefaultRangeHostComponent {
+    config = rangeConfig;
+    control = new FormControl<Date[]>(RANGE_VALUE);
+}
+
+@Component({
+    selector: 'evo-onpush-single-host',
+    template: `<evo-datepicker [config]="config" [formControl]="control" />`,
+    standalone: true,
+    imports: [ReactiveFormsModule, EvoDatepickerComponent],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class OnPushSingleHostComponent {
+    config = singleConfig;
+    @Input() control = new FormControl<Date[]>(SINGLE_VALUE);
+}
+
+@Component({
+    selector: 'evo-onpush-async-host',
+    template: `
+        @if (loaded) {
+            <evo-datepicker [config]="config" theme="range" [formControl]="control" />
+        }
+    `,
+    standalone: true,
+    imports: [ReactiveFormsModule, EvoDatepickerComponent],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class OnPushAsyncHostComponent {
+    private readonly cdr = inject(ChangeDetectorRef);
+
+    config = rangeConfig;
+    control = new FormControl<Date[]>(null);
+    loaded = false;
+
+    // Эмуляция боевого пути: ответ HTTP приходит макрозадачей, поддерево создаётся внутри того же
+    // прохода CD - следующего тика, в котором мог бы сработать markForCheck из ngAfterViewInit, нет.
+    load(): void {
+        of(RANGE_VALUE)
+            .pipe(delay(0))
+            .subscribe((value) => {
+                this.control.setValue(value);
+                this.loaded = true;
+                this.cdr.markForCheck();
+            });
+    }
+}
+
+@Component({
+    selector: 'evo-onpush-branch',
+    template: `<evo-datepicker [config]="config" [theme]="theme" [formControl]="control" />`,
+    standalone: true,
+    imports: [ReactiveFormsModule, EvoDatepickerComponent],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class OnPushBranchComponent {
+    @Input() config: FlatpickrOptions;
+    @Input() theme: string;
+    @Input() control: FormControl<Date[]>;
+}
+
+// Боевая расстановка потребителя: обычный корень, между ним и датапикером - OnPush-компонент.
+// Проход CD от корня в такую ветку не заходит, пока её кто-нибудь не пометит грязной.
+@Component({
+    selector: 'evo-default-root-host',
+    template: `<evo-onpush-branch [config]="config" [theme]="theme" [control]="control" />`,
+    standalone: true,
+    imports: [OnPushBranchComponent],
+})
+class DefaultRootHostComponent {
+    @Input() config = rangeConfig;
+    @Input() theme = 'range';
+    @Input() control = new FormControl<Date[]>(null);
+}
+
+@Component({
+    selector: 'evo-onpush-masked-host',
+    template: `<evo-datepicker [config]="config" [maskedInput]="true" [formControl]="control" />`,
+    standalone: true,
+    imports: [ReactiveFormsModule, EvoDatepickerComponent],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class OnPushMaskedHostComponent {
+    config = maskedConfig;
+    control = new FormControl<Date[]>(SINGLE_VALUE);
+}
+
+@Component({
+    selector: 'evo-onpush-setdate-host',
+    template: `<evo-datepicker [config]="config" theme="range" [setDate]="dates" />`,
+    standalone: true,
+    imports: [EvoDatepickerComponent],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class OnPushSetDateHostComponent {
+    config = rangeConfig;
+    @Input() dates: Date[] = null;
+}
+
+const valueSpan = (fixture: ComponentFixture<unknown>): HTMLElement =>
+    fixture.nativeElement.querySelector('.evo-datepicker__value');
+const emptyText = (fixture: ComponentFixture<unknown>): HTMLElement =>
+    fixture.nativeElement.querySelector('.evo-datepicker__empty-text');
+const pickerInput = (fixture: ComponentFixture<unknown>): HTMLInputElement =>
+    fixture.nativeElement.querySelector('.evo-datepicker__input');
+
+describe('EvoDatepickerComponent: первый рендер под OnPush-хостом', () => {
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                OnPushRangeHostComponent,
+                DefaultRangeHostComponent,
+                OnPushSingleHostComponent,
+                OnPushAsyncHostComponent,
+                OnPushSetDateHostComponent,
+                OnPushMaskedHostComponent,
+                DefaultRootHostComponent,
+            ],
+        }).compileComponents();
+    }));
+
+    // Значение из форм-контрола должно быть видно сразу, без единого события в поддереве.
+    it('range: показывает значение форм-контрола после первого detectChanges', () => {
+        const fixture = TestBed.createComponent(OnPushRangeHostComponent);
+
+        fixture.detectChanges();
+
+        const span = valueSpan(fixture);
+        expect(span).not.toBeNull();
+        expect(span.textContent.trim()).toBe(pickerInput(fixture).value);
+        expect(span.textContent).toContain('05.04.2018');
+        expect(emptyText(fixture)).toBeNull();
+    });
+
+    it('range: значение приходит асинхронно, поддерево создаётся внутри прохода CD', fakeAsync(() => {
+        const fixture = TestBed.createComponent(OnPushAsyncHostComponent);
+        fixture.detectChanges();
+
+        fixture.componentInstance.load();
+        tick();
+        fixture.detectChanges();
+
+        const span = valueSpan(fixture);
+        expect(span).not.toBeNull();
+        expect(span.textContent.trim()).toBe(pickerInput(fixture).value);
+    }));
+
+    // Под Default-хостом тот же дефект виден как NG0100: @if переключается уже после проверки вью.
+    it('range: под обычным хостом первый detectChanges не бросает NG0100', () => {
+        const fixture = TestBed.createComponent(DefaultRangeHostComponent);
+
+        expect(() => fixture.detectChanges()).not.toThrow();
+        expect(valueSpan(fixture)).not.toBeNull();
+    });
+
+    it('single: поле не скрыто и заглушка "Дата" не показана', () => {
+        const fixture = TestBed.createComponent(OnPushSingleHostComponent);
+
+        fixture.detectChanges();
+
+        const input = pickerInput(fixture);
+        expect(input.value).toBe('05.04.2018');
+        expect(input.classList.contains('evo-datepicker__input_hidden')).toBeFalse();
+        expect(emptyText(fixture)).toBeNull();
+    });
+
+    it('range: пустой контрол показывает "За период" и не рисует значение', () => {
+        const fixture = TestBed.createComponent(OnPushRangeHostComponent);
+        fixture.componentRef.setInput('control', new FormControl<Date[]>(null));
+
+        fixture.detectChanges();
+
+        expect(valueSpan(fixture)).toBeNull();
+        expect(emptyText(fixture).textContent.trim()).toBe('За период');
+    });
+
+    it('single: пустой контрол показывает "Дата" и скрывает поле', () => {
+        const fixture = TestBed.createComponent(OnPushSingleHostComponent);
+        fixture.componentRef.setInput('control', new FormControl<Date[]>(null));
+
+        fixture.detectChanges();
+
+        expect(emptyText(fixture).textContent.trim()).toBe('Дата');
+        expect(pickerInput(fixture).classList.contains('evo-datepicker__input_hidden')).toBeTrue();
+    });
+
+    it('[setDate]: значение задано на момент создания', () => {
+        const fixture = TestBed.createComponent(OnPushSetDateHostComponent);
+        fixture.componentRef.setInput('dates', RANGE_VALUE);
+
+        expect(() => fixture.detectChanges()).not.toThrow();
+        expect(pickerInput(fixture).value).toContain('05.04.2018');
+        expect(valueSpan(fixture)).not.toBeNull();
+    });
+
+    it('[setDate]: значение меняется после инициализации', () => {
+        const fixture = TestBed.createComponent(OnPushSetDateHostComponent);
+        fixture.detectChanges();
+
+        fixture.componentRef.setInput('dates', RANGE_VALUE);
+        fixture.detectChanges();
+
+        expect(pickerInput(fixture).value).toContain('05.04.2018');
+        expect(valueSpan(fixture)).not.toBeNull();
+        expect(emptyText(fixture)).toBeNull();
+    });
+
+    // Программная запись значения в контрол не помечает OnPush-ветку грязной,
+    // поэтому пометить её должен сам компонент - иначе заглушка остаётся поверх заполненного поля.
+    it('range: setValue из внешнего источника обновляет значение сквозь OnPush-ветку', () => {
+        const fixture = TestBed.createComponent(DefaultRootHostComponent);
+        const control = new FormControl<Date[]>(null);
+        fixture.componentRef.setInput('control', control);
+        fixture.detectChanges();
+        expect(valueSpan(fixture)).toBeNull();
+
+        control.setValue(RANGE_VALUE);
+        fixture.detectChanges();
+
+        const span = valueSpan(fixture);
+        expect(span).not.toBeNull();
+        expect(span.textContent.trim()).toBe(pickerInput(fixture).value);
+        expect(emptyText(fixture)).toBeNull();
+    });
+
+    it('single: setValue из внешнего источника снимает заглушку "Дата" сквозь OnPush-ветку', () => {
+        const fixture = TestBed.createComponent(DefaultRootHostComponent);
+        const control = new FormControl<Date[]>(null);
+        fixture.componentRef.setInput('config', singleConfig);
+        fixture.componentRef.setInput('theme', undefined);
+        fixture.componentRef.setInput('control', control);
+        fixture.detectChanges();
+        expect(emptyText(fixture).textContent.trim()).toBe('Дата');
+
+        control.setValue(SINGLE_VALUE);
+        fixture.detectChanges();
+
+        expect(emptyText(fixture)).toBeNull();
+        expect(pickerInput(fixture).classList.contains('evo-datepicker__input_hidden')).toBeFalse();
+    });
+
+    it('маска ввода не искажает начальное значение', () => {
+        const fixture = TestBed.createComponent(OnPushMaskedHostComponent);
+
+        fixture.detectChanges();
+
+        expect(pickerInput(fixture).value).toBe('05.04.2018');
+    });
+
+    it('инпут остаётся readonly, когда config.allowInput не задан', () => {
+        const fixture = TestBed.createComponent(OnPushSingleHostComponent);
+
+        fixture.detectChanges();
+
+        expect(pickerInput(fixture).readOnly).toBeTrue();
+    });
+
+    it('range: значение не пропадает после открытия и закрытия пикера', () => {
+        const fixture = TestBed.createComponent(OnPushRangeHostComponent);
+        fixture.detectChanges();
+        const root: HTMLElement = fixture.nativeElement.querySelector('.evo-datepicker');
+
+        root.dispatchEvent(new MouseEvent('click'));
+        fixture.detectChanges();
+        expect(valueSpan(fixture)).not.toBeNull();
+
+        document.body.dispatchEvent(new MouseEvent('mousedown', {button: 0, bubbles: true}));
+        fixture.detectChanges();
+
+        const span = valueSpan(fixture);
+        expect(span).not.toBeNull();
+        expect(span.textContent.trim()).toBe(pickerInput(fixture).value);
+    });
+});


### PR DESCRIPTION
Перенос фикса из #1319 в линию 20.x. Изменения те же построчно: в `master` и `beta` компонент отличался только форматированием и снятым `standalone: true`, поэтому дифф двух ветвей совпадает.

## Суть

`evo-datepicker` внутри компонента со стратегией OnPush открывался с визуально пустым полем, хотя значение в форме было: дата появлялась только после первого события в поддереве.
Причина - шаблон рисовал выбранную дату из DOM-свойства нативного инпута, а заполняет это свойство flatpickr уже после того, как Angular проверил вью, и никто не помечал поддерево изменившимся.
Теперь отображаемый текст живёт в сигнале, который заполняется из инстанса flatpickr, поэтому запись значения сама помечает вью на обновление и Angular догоняет её в том же проходе change detection.

Дефект не связан со сменой версии Angular: он одинаково воспроизводится на 17.3.10 и 20.3.25, в обеих значение не видно под OnPush и видно под Default. Триггером у потребителя стал переход на OnPush, а не бамп Angular. У Default-потребителей этот же дефект всё это время давал в консоли разработки ошибку `NG0100 ExpressionChangedAfterItHasBeenChecked`.

Публичный контракт не меняется: те же входы и выходы, те же классы в разметке.

## Что изменено

- `displayValue` - сигнал с отображаемым текстом; шаблон рисует `span.evo-datepicker__value` по нему, а не по `input.value`.
  Текст берётся только из инстанса flatpickr (`instance.input.value`), своего форматирования нет: оно учитывает разделитель диапазона из локали и схлопывание одинаковых дат.
- Точки синхронизации: конец `ngAfterViewInit`, `setDateFromInput()` (все программные пути, включая `writeValue` и `[setDate]`) и хук `onChange` инстанса.
  Хук вешается через массив хуков инстанса (`instance.config.onChange.push`), а не через `getDefaultFlatpickrOptions()`: колбэки оттуда перетираются конфигурацией потребителя.
- `isValueExist()` выводится из того же сигнала; ветвление `pendingValue -> config.defaultDate -> selectedDates` убрано.
- Два падения, мешавших регрессионным спекам: `[setDate]`, заданный на момент создания (`ngOnChanges` выполняется раньше `ngAfterViewInit`), и уничтожение компонента, не дошедшего до `ngAfterViewInit`.
- Новый файл спеков `evo-datepicker.onpush.spec.ts` - 14 проверок.

Механическое (можно листать бегло):

- обращение к инстансу flatpickr через поле компонента вместо `flatpickrElement.nativeElement._flatpickr` - это один и тот же объект, отдельным первым коммитом.

## Риски и миграция

Миграция потребителям не нужна, откат равен revert коммитов.

На что стоит посмотреть ревьюеру:

- Отрисованный текст теперь обновляется в известных точках, а не перечитывается из DOM на каждом проходе change detection.
  Если потребитель передаёт собственный `config.onChange`, наш колбэк вытесняется - поэтому синхронизация повешена на массив хуков инстанса, который перетереть нельзя.
  Отдельный давний дефект (свой `onChange` в конфигурации отключает интеграцию с формой целиком, вместе с записью значения в форму) в этом PR не чинится.
- Пока значения нет, разметка не меняется: спана значения нет, заглушка и класс `evo-datepicker__input_hidden` работают как раньше.
  На первом проходе заглушка успевает отрисоваться и снимается в том же синхронном проходе, до отрисовки браузером.

## Как проверить

```
npx ng test evo-ui-kit --browsers=ChromeHeadless --watch=false --include='**/evo-datepicker/*.spec.ts'
```

На этой ветке (Angular 20.3.25): 25 спеков зелёные - 14 новых и 11 существующих. Линт и сборка библиотеки зелёные.

Дефект в этой линии подтверждён прямо здесь: если откатить правку компонента и шаблона, оставив новый файл спеков, 7 из 14 проверок краснеют.

Ключевые проверки в новом файле:

- значение из форм-контрола видно сразу после первого `detectChanges()` под OnPush-хостом, без единого события в поддереве;
- то же, когда компонент создаётся внутри прохода change detection от ответа HTTP;
- внешний `setValue()` доезжает до экрана сквозь OnPush-ветку (расстановка Default-корень -> OnPush-компонент -> датапикер);
- под обычным хостом первый `detectChanges()` больше не бросает `NG0100`;
- маска ввода не искажает начальное значение, инпут остаётся `readonly` при `allowInput: false`.
